### PR TITLE
v1.1.0: multi-account, preferences, focus time, conflicts, reschedule, time audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,68 @@
 All notable changes to this project are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-09-05
+
+Multiple accounts, saved scheduling preferences, and a scheduling brain that
+reasons about your working hours rather than just your calendar. 15 tools ->
+23. Nothing is removed and nothing is renamed.
+
+### Added
+
+- **Multiple Google accounts.** `calendar-mcp auth --account work` signs in an
+  additional named account; `calendar-mcp accounts` lists them with their token
+  files and sign-in state. Every calendar tool gained an optional trailing
+  `account` argument, and `detect_conflicts` takes `accounts` (a list) so it can
+  check them all at once. New `list_accounts` tool, new
+  `CALENDAR_MCP_DEFAULT_ACCOUNT` environment variable.
+- **A config directory.** Tokens (`accounts/<name>.json`) and `preferences.json`
+  now live in the OS user config directory, overridable with
+  `CALENDAR_MCP_CONFIG_DIR`.
+- **Saved scheduling preferences**: timezone, per-weekday working hours, lunch,
+  `buffer_minutes`, `min_focus_block_minutes` and `focus_calendar_id`, read with
+  `get_preferences` and updated with `set_preferences`. Both are local-only and
+  never call Google. `set_preferences` merges field by field and validates the
+  merged result before writing, so a rejected change leaves the saved file
+  intact; `working_hours` is the exception and replaces the whole schedule.
+- **`find_focus_time`** - uninterrupted blocks inside the working hours, with
+  lunch, booked events and the buffer removed, longest first.
+- **`block_focus_time`** - books those blocks as events (busy, reminders off,
+  no notifications), trimming the last one to the hours actually requested.
+  `dry_run: true` previews without writing.
+- **`detect_conflicts`** - genuine overlaps and too-tight transitions, across
+  every signed-in account, so a work meeting clashing with a personal one is
+  visible. Declined, free-marked, cancelled and (by default) all-day events are
+  ignored.
+- **`suggest_reschedule`** - ranked alternative times for an existing meeting,
+  preserving its duration, ranked by fewest attendee conflicts and preferring
+  its current day. Suggests only; `apply: true` performs the move.
+- **`time_audit`** - meeting hours as a share of available working hours,
+  grouped by day or week, broken down by meeting size, attendee domain,
+  recurring vs one-off, and the people you spend the most time with.
+- `platformdirs` is now a dependency.
+
+### Changed
+
+- Tool functions moved out of `server.py` into a `calendar_mcp.tools`
+  subpackage, one module per subject area. `server.py` keeps the `MCPServer`,
+  the shared helpers and the credential provider, and still re-exports every
+  tool by name. New internal modules: `accounts.py`, `preferences.py`,
+  `timeutil.py`.
+- Credentials are cached per account rather than globally, and the
+  calendar-timezone cache is now keyed by account as well as calendar ID, so
+  one account's `primary` can no longer supply another account's timezone when
+  a naive timestamp is resolved.
+- Events carry Google's `transparency` field, so an event the user marked
+  "free" is correctly ignored by `detect_conflicts` and `time_audit`.
+- `TOKEN_FILE_PATH` now means "the default account's token". It, and an existing
+  `.gcp-saved-tokens.json` in the working directory, continue to work unchanged.
+
+### Compatibility
+
+- All 15 tools from 1.0 keep their names and their existing parameters; the only
+  change is an added optional `account`. Existing prompts and client configs
+  keep working.
+
 ## [1.0.1] - 2026-09-05
 
 - Add the MCP Registry ownership marker (`mcp-name`) to the README so the package can be listed at registry.modelcontextprotocol.io.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # calendar-mcp
 
-An MCP server that gives an LLM client read and write access to your Google Calendar. It runs as a single process — stdio by default, streamable HTTP optionally — and exposes 15 tools with structured output: listing and searching calendars and events, creating, updating, moving, RSVPing to and deleting events, free/busy queries, busyness analysis, recurring-event projection, and finding a mutual slot and booking it. Authentication is Google OAuth 2.0 (Desktop app flow); the token is cached locally and refreshed automatically.
+An MCP server that gives an LLM client read and write access to your Google Calendar. It runs as a single process — stdio by default, streamable HTTP optionally — and exposes 23 tools with structured output: listing and searching calendars and events, creating, updating, moving, RSVPing to and deleting events, free/busy queries, busyness analysis, recurring-event projection, and finding a mutual slot and booking it. On top of that it has a scheduling brain that knows your working hours: finding and booking focus time, detecting double-bookings across several accounts at once, proposing better times for a meeting, and auditing where your week actually went. Authentication is Google OAuth 2.0 (Desktop app flow); tokens are cached locally, per account, and refreshed automatically.
 
 ## Quick start
 
@@ -19,7 +19,7 @@ GOOGLE_CLIENT_SECRET='...'
 uvx calendar-mcp-server auth
 ```
 
-This opens a browser, and saves a token to `.gcp-saved-tokens.json` (override with `TOKEN_FILE_PATH`). Verify it with `calendar-mcp check`. After that the server runs non-interactively — it never opens a browser on its own unless you set `CALENDAR_MCP_ALLOW_BROWSER_AUTH=1`.
+This opens a browser and saves a token in the config directory (see [Accounts](#accounts)); if you already have a `.gcp-saved-tokens.json` or set `TOKEN_FILE_PATH`, that file is used instead. Verify it with `calendar-mcp check`. Add more Google accounts with `calendar-mcp auth --account work`. After that the server runs non-interactively — it never opens a browser on its own unless you set `CALENDAR_MCP_ALLOW_BROWSER_AUTH=1`.
 
 > The PyPI distribution is `calendar-mcp-server`. It installs two identical console scripts, `calendar-mcp` and `calendar-mcp-server`, so `uvx calendar-mcp-server` and a local `calendar-mcp` are the same command.
 
@@ -54,7 +54,7 @@ claude mcp add calendar \
 
 **Cursor** — `.cursor/mcp.json` (project) or `~/.cursor/mcp.json` (global): same `mcpServers` block as above.
 
-**Any other client** that speaks the standard `mcpServers` JSON takes the same entry. Set `TOKEN_FILE_PATH` to an absolute path in client configs — the client decides the working directory, and a relative path may not resolve to where `calendar-mcp auth` wrote the token.
+**Any other client** that speaks the standard `mcpServers` JSON takes the same entry. `TOKEN_FILE_PATH` is optional now that tokens default to the OS config directory, which does not depend on the working directory the client picks — but if you do set it, make it an absolute path.
 
 ## Remote / HTTP mode
 
@@ -68,25 +68,181 @@ The MCP endpoint is then `http://127.0.0.1:8000/mcp` (change the path with `--pa
 
 ## Tools
 
-| Tool | Description |
-| --- | --- |
-| `list_calendars` | List the calendars the user can see, with IDs and timezones. |
-| `find_events` | Search a calendar for events, expanding recurring series into instances. |
-| `check_attendee_status` | Report who accepted, declined or has not answered an invitation. |
-| `query_free_busy` | Busy intervals for one or more calendars, without event details. |
-| `analyze_busyness` | Per-day event count and total scheduled minutes over a range. |
-| `project_recurring_events` | Compute future occurrences from recurrence rules. |
-| `create_calendar` | Create a new secondary calendar. |
-| `create_event` | Create an event with explicit start/end times and optional attendees. |
-| `quick_add_event` | Create an event from a plain-English phrase, parsed by Google. |
-| `update_event` | Change fields on an event; omitted fields are left untouched. |
-| `move_event` | Reschedule an event, and/or move it to another calendar. |
-| `add_attendee` | Invite one or more people to an existing event. |
-| `respond_to_event` | Set your own RSVP (`accepted`/`declined`/`tentative`/`needsAction`). |
-| `schedule_mutual` | Find the first slot where everyone is free, then book it. |
-| **`delete_event`** | **Destructive.** Permanently delete an event. Asks the client to confirm via elicitation when supported. |
+Read-only tools never change anything. "Writes" tools create or modify events;
+`delete_event` is the only one that destroys data.
 
-The first six are read-only. `delete_event` is the only tool marked destructive; the rest write but do not destroy. All times are ISO 8601 strings — a naive timestamp is interpreted in the target calendar's own timezone.
+**Calendars and events**
+
+| Tool | | Description |
+| --- | --- | --- |
+| `list_calendars` | read | List the calendars the user can see, with IDs and timezones. |
+| `find_events` | read | Search a calendar for events, expanding recurring series into instances. |
+| `check_attendee_status` | read | Report who accepted, declined or has not answered an invitation. |
+| `query_free_busy` | read | Busy intervals for one or more calendars, without event details. |
+| `analyze_busyness` | read | Per-day event count and total scheduled minutes over a range. |
+| `project_recurring_events` | read | Compute future occurrences from recurrence rules. |
+| `create_calendar` | writes | Create a new secondary calendar. |
+| `create_event` | writes | Create an event with explicit start/end times and optional attendees. |
+| `quick_add_event` | writes | Create an event from a plain-English phrase, parsed by Google. |
+| `update_event` | writes | Change fields on an event; omitted fields are left untouched. |
+| `move_event` | writes | Reschedule an event, and/or move it to another calendar. |
+| `add_attendee` | writes | Invite one or more people to an existing event. |
+| `respond_to_event` | writes | Set your own RSVP (`accepted`/`declined`/`tentative`/`needsAction`). |
+| `schedule_mutual` | writes | Find the first slot where everyone is free, then book it. |
+| **`delete_event`** | **destroys** | Permanently delete an event. Asks the client to confirm via elicitation when supported. |
+
+**Scheduling brain** — these read your saved preferences (working hours, lunch, buffer, minimum focus block).
+
+| Tool | | Description |
+| --- | --- | --- |
+| `find_focus_time` | read | Uninterrupted blocks in a window that could be used for deep work, longest first. |
+| `detect_conflicts` | read | Double-bookings and too-tight transitions, across every signed-in account at once. |
+| `time_audit` | read | Where the time went: meeting hours, by size, domain, recurrence and person. |
+| `suggest_reschedule` | writes *(opt-in)* | Ranked better times for an existing meeting. Suggests only, unless `apply: true`. |
+| `block_focus_time` | writes | Book the best free blocks as focus time. `dry_run: true` to preview. |
+
+**Local configuration** — no Google call, no `account` argument.
+
+| Tool | | Description |
+| --- | --- | --- |
+| `list_accounts` | read | The accounts you have signed in, and which is the default. |
+| `get_preferences` | read | Working hours, lunch, buffer, minimum focus block, focus calendar. |
+| `set_preferences` | writes | Update and save those preferences. Local file only. |
+
+Every calendar tool takes an optional trailing `account` argument (`detect_conflicts`
+takes `accounts`, a list, because checking several at once is the point). All times
+are ISO 8601 strings — a naive timestamp is interpreted in the target calendar's own
+timezone.
+
+### Scheduling brain
+
+The five scheduling tools share one idea: your calendar is not the same as your
+availability. They start from your working hours, subtract lunch, subtract what is
+already booked, and subtract the buffer you want around meetings — then reason about
+what is left.
+
+Prompts that exercise them:
+
+- "Find me six hours of focus time next week and block it out — show me the times first."
+- "Is anything double-booked between my work and personal calendars this week?"
+- "My Thursday is back-to-back. Suggest better times for the design review."
+- "Where did my time go last month? Who am I spending it with?"
+- "I need a 90-minute deep work block before Friday. Is there one?"
+
+`find_focus_time` reports what exists; `block_focus_time` defends it by creating
+events (busy, reminders off, nobody notified), trimming the last block so it books
+exactly the hours you asked for rather than a whole afternoon. `detect_conflicts`
+separates genuine overlaps from *tight* transitions that merely break your buffer,
+and ignores events you declined, events marked free, and (by default) all-day
+entries. `suggest_reschedule` keeps the meeting's duration, ranks candidate slots by
+fewest attendee conflicts and prefers the event's current day, and moves nothing
+unless you pass `apply: true`.
+
+### Time audit
+
+`time_audit` answers "how much of my week is meetings?" in one pass, grouped by
+`day` or `week`:
+
+```
+2026-08-01 .. 2026-09-01, Europe/Berlin, grouped by week
+  Meetings:         41.5 h across 63 meetings
+  Working hours:    152.0 h available (lunch removed)
+  In working hours: 38.0 h -> 25% of the week
+  Busiest week:     2026-W34, 14.0 h
+  Heaviest day:     2026-08-20, 6.5 h
+  By size:          1:1 18.0 h | small 15.5 h | large 8.0 h
+  By recurrence:    recurring 26.0 h | one-off 15.5 h
+  Top people:       a.schmidt@example.com 9.0 h | j.lee@example.com 7.5 h
+```
+
+Declined meetings, events marked free and all-day entries are left out by default;
+`include_declined` and `include_all_day` bring them back.
+
+### Safety
+
+- **`delete_event` is the only destructive tool.** It asks the client to confirm
+  through MCP elicitation when the client supports it, and proceeds normally when
+  it does not.
+- **`block_focus_time` takes `dry_run`.** Run it with `dry_run: true` to see the
+  exact blocks it would book before anything is written.
+- **`suggest_reschedule` does not move anything by default.** `apply` is `false`
+  and has to be set explicitly, once the user has agreed to a time.
+- **Everything else that writes is additive** — creating or editing an event —
+  and `update_event` leaves fields you omit untouched.
+- **`list_accounts`, `get_preferences` and `set_preferences` never touch Google.**
+  They read and write local files in the config directory.
+
+## Accounts
+
+You can sign in more than one Google account and pick between them per call.
+
+```bash
+calendar-mcp auth                    # the default account
+calendar-mcp auth --account work     # a second, named account
+calendar-mcp accounts                # list them, with token paths and sign-in state
+```
+
+Every calendar tool takes an optional `account` argument naming one of these
+("what's on my work calendar tomorrow?"). Omit it and the server uses the
+default: `CALENDAR_MCP_DEFAULT_ACCOUNT` if set, otherwise the account named
+`default`, otherwise the only account you have signed in. `list_accounts`
+returns the same list the CLI prints, so the model can discover the names
+itself.
+
+Account names must match `[A-Za-z0-9][A-Za-z0-9_-]{0,63}`.
+
+**Where things live.** Tokens and preferences are stored in the OS user config
+directory — `%LOCALAPPDATA%\calendar-mcp` on Windows, `~/.config/calendar-mcp`
+on Linux, `~/Library/Application Support/calendar-mcp` on macOS — with one
+token file per account under `accounts/`. Override the whole directory with
+`CALENDAR_MCP_CONFIG_DIR`.
+
+**Back-compat.** `TOKEN_FILE_PATH` still works and now means *the default
+account's token*. If it is set, or if a `.gcp-saved-tokens.json` exists in the
+working directory, that file is used for the `default` account and nothing
+moves. Named accounts always live in the config directory.
+
+## Preferences
+
+The server remembers how you like your week to be shaped, so the scheduling
+tools do not have to guess. Read them with `get_preferences` and change them
+with `set_preferences` ("I start at 8 and I want 15 minutes between meetings").
+Preferences are global — they describe you, not one account — and are stored as
+`preferences.json` in the config directory.
+
+| Field | Default | Meaning |
+| --- | --- | --- |
+| `timezone` | unset | IANA zone the working hours are expressed in, e.g. `Europe/Berlin`. |
+| `working_hours` | Mon–Fri 09:00–17:00 | Per weekday (`mon`…`sun`), a list of `["HH:MM", "HH:MM"]` spans. |
+| `buffer_minutes` | `0` | Gap to leave either side of a meeting when proposing times. |
+| `min_focus_block_minutes` | `60` | Shortest free stretch that still counts as usable focus time. |
+| `lunch` | unset | A daily break carved out of the working hours. |
+| `focus_calendar_id` | `primary` | Calendar that focus blocks are booked on. |
+
+```json
+{
+  "timezone": "Europe/Berlin",
+  "working_hours": {
+    "mon": [["09:00", "12:00"], ["13:00", "18:00"]],
+    "tue": [["09:00", "17:00"]],
+    "wed": [["09:00", "17:00"]],
+    "thu": [["09:00", "17:00"]],
+    "fri": [["09:00", "15:00"]],
+    "sat": [],
+    "sun": []
+  },
+  "buffer_minutes": 15,
+  "min_focus_block_minutes": 90,
+  "lunch": ["12:30", "13:15"],
+  "focus_calendar_id": "primary"
+}
+```
+
+`set_preferences` merges: only the arguments you pass change, and the merged
+result is validated before it is written, so a rejected change leaves the saved
+file untouched. The one exception is `working_hours`, which is a **whole-schedule
+replacement** — weekdays you leave out of the dict become non-working days. Pass
+`clear_lunch: true` to remove a lunch break.
 
 ## Configuration
 
@@ -94,7 +250,9 @@ The first six are read-only. `delete_event` is the only tool marked destructive;
 | --- | --- | --- |
 | `GOOGLE_CLIENT_ID` | — | OAuth client ID (required). |
 | `GOOGLE_CLIENT_SECRET` | — | OAuth client secret (required). |
-| `TOKEN_FILE_PATH` | `.gcp-saved-tokens.json` | Where the OAuth token is cached. |
+| `TOKEN_FILE_PATH` | `.gcp-saved-tokens.json` | Where the **default** account's OAuth token is cached. |
+| `CALENDAR_MCP_CONFIG_DIR` | OS user config dir | Directory holding per-account tokens (`accounts/`) and `preferences.json`. |
+| `CALENDAR_MCP_DEFAULT_ACCOUNT` | `default` | Account used when a tool's `account` argument is omitted. |
 | `CALENDAR_SCOPES` | `https://www.googleapis.com/auth/calendar` | Scope requested. Use `.../auth/calendar.readonly` for read-only. |
 | `OAUTH_CALLBACK_PORT` | `8080` | Local port for the OAuth callback during `calendar-mcp auth`. |
 | `CALENDAR_MCP_ALLOW_BROWSER_AUTH` | unset | Set to `1` to let the server itself open a browser when no token exists. Off by default so a stdio server never hangs. |
@@ -110,8 +268,9 @@ A `.env` file in the working directory is loaded on startup. Logs never go to st
 ```
 calendar-mcp [--transport {stdio,http}] [--host H] [--port P] [--path /mcp] [--log-level L]
 calendar-mcp serve ...     # explicit form of the default
-calendar-mcp auth [--no-browser]
-calendar-mcp check         # token status + calendar list; exit 1 if no valid token
+calendar-mcp auth [--account NAME] [--no-browser]
+calendar-mcp accounts      # list known accounts; exit 1 if none is signed in
+calendar-mcp check [--account NAME]   # token status + calendar list; exit 1 if no valid token
 calendar-mcp --version
 ```
 
@@ -134,7 +293,17 @@ uv pip install -e ".[dev]"
 pytest
 ```
 
-Layout: `calendar_mcp/server.py` (the `MCPServer` and its tools), `calendar_actions.py` (Google API calls), `analysis.py`, `models.py` (pydantic input/output models), `auth.py` (OAuth), `cli.py` (the `calendar-mcp` command). `scripts/smoke_stdio.py` spawns a real stdio server and checks the handshake and tool list.
+Layout: `calendar_mcp/server.py` (the `MCPServer`, shared helpers and the credential provider), `tools/` (one module per tool area — the tool functions themselves), `calendar_actions.py` (Google API calls), `analysis.py`, `timeutil.py` (pure interval maths), `accounts.py` (multi-account token paths), `preferences.py` (the saved schedule), `models.py` (pydantic input/output models), `auth.py` (OAuth), `cli.py` (the `calendar-mcp` command). `scripts/smoke_stdio.py` spawns a real stdio server and checks the handshake and tool list.
+
+## Upgrading from 1.0
+
+Nothing breaks. All 15 original tools keep their names and their existing
+parameters; each simply gained an optional trailing `account`. Your existing
+`TOKEN_FILE_PATH` keeps working, and now names the default account's token.
+What is new: multiple accounts, saved scheduling preferences, and eight new
+tools (`find_focus_time`, `block_focus_time`, `detect_conflicts`,
+`suggest_reschedule`, `time_audit`, `list_accounts`, `get_preferences`,
+`set_preferences`).
 
 ## Upgrading from 0.x
 

--- a/calendar_mcp/__init__.py
+++ b/calendar_mcp/__init__.py
@@ -5,6 +5,6 @@ line entry point in :mod:`calendar_mcp.cli`. Both are imported lazily here so
 that ``import calendar_mcp`` stays cheap and side-effect free.
 """
 
-__version__ = "1.0.1"
+__version__ = "1.1.0"
 
 __all__ = ["__version__"]

--- a/calendar_mcp/accounts.py
+++ b/calendar_mcp/accounts.py
@@ -1,0 +1,304 @@
+"""Named Google accounts and where their OAuth tokens live.
+
+calendar-mcp can be signed in to several Google accounts at once. Each one has
+a short name -- ``default``, ``work``, ``personal`` -- and its own cached OAuth
+token::
+
+    <config dir>/accounts/<name>.json
+
+``<config dir>`` is ``$CALENDAR_MCP_CONFIG_DIR`` when set, and otherwise the
+platform's user config directory (``platformdirs.user_config_dir`` under the
+app name ``calendar-mcp``): ``%APPDATA%\\calendar-mcp`` on Windows,
+``~/.config/calendar-mcp`` on Linux, ``~/Library/Application Support/calendar-mcp``
+on macOS.
+
+Back-compatibility: v1.0 kept a single token at ``$TOKEN_FILE_PATH`` (default
+``./.gcp-saved-tokens.json``). If either is present it *is* the ``default``
+account, so an existing install keeps working with no migration and no re-auth.
+
+Nothing here touches the network. Reading an account's token to report whether
+it is usable is a local file parse.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from .models import AccountInfo
+
+logger = logging.getLogger(__name__)
+
+APP_NAME = "calendar-mcp"
+
+CONFIG_DIR_ENV = "CALENDAR_MCP_CONFIG_DIR"
+DEFAULT_ACCOUNT_ENV = "CALENDAR_MCP_DEFAULT_ACCOUNT"
+TOKEN_FILE_ENV = "TOKEN_FILE_PATH"
+
+DEFAULT_ACCOUNT = "default"
+LEGACY_TOKEN_FILE = ".gcp-saved-tokens.json"
+ACCOUNTS_SUBDIR = "accounts"
+
+# Account names become file names, so keep them boring: no separators, no dots
+# leading the name, nothing that could escape the accounts directory.
+_NAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
+
+
+class AccountError(ValueError):
+    """Raised for a malformed or unusable account name."""
+
+
+# ---------------------------------------------------------------------------
+# Locations
+# ---------------------------------------------------------------------------
+
+
+def config_dir() -> Path:
+    """The directory holding account tokens and ``preferences.json``.
+
+    ``$CALENDAR_MCP_CONFIG_DIR`` wins when set; otherwise the platform's user
+    config directory for the app. The directory is not created here -- the
+    writers (:func:`ensure_config_dir`) do that.
+    """
+    override = os.getenv(CONFIG_DIR_ENV)
+    if override and override.strip():
+        return Path(override.strip()).expanduser()
+    try:
+        from platformdirs import user_config_dir
+
+        return Path(user_config_dir(APP_NAME, appauthor=False))
+    except Exception:  # pragma: no cover - platformdirs missing or unhappy
+        logger.warning("platformdirs is unavailable; falling back to ~/.calendar-mcp")
+        return Path.home() / ".calendar-mcp"
+
+
+def ensure_config_dir() -> Path:
+    """Creates and returns the config directory."""
+    target = config_dir()
+    target.mkdir(parents=True, exist_ok=True)
+    return target
+
+
+def accounts_dir() -> Path:
+    """The ``<config dir>/accounts`` directory holding one token file per account."""
+    return config_dir() / ACCOUNTS_SUBDIR
+
+
+def ensure_accounts_dir() -> Path:
+    """Creates and returns the accounts directory."""
+    target = accounts_dir()
+    target.mkdir(parents=True, exist_ok=True)
+    return target
+
+
+# ---------------------------------------------------------------------------
+# Names
+# ---------------------------------------------------------------------------
+
+
+def validate_account_name(name: str) -> str:
+    """Normalises and checks an account name.
+
+    Returns:
+        The trimmed name.
+
+    Raises:
+        AccountError: If the name is empty or contains anything but letters,
+            digits, ``-`` and ``_``.
+    """
+    text = (name or "").strip()
+    if not _NAME_PATTERN.match(text):
+        raise AccountError(
+            f"Invalid account name {name!r}. Use letters, digits, '-' and '_' "
+            "(starting with a letter or digit), e.g. 'work' or 'personal'."
+        )
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Token paths
+# ---------------------------------------------------------------------------
+
+
+def legacy_token_path() -> Optional[str]:
+    """The pre-multi-account token location, when one is in play.
+
+    Returns ``$TOKEN_FILE_PATH`` if that variable is set (whether or not the
+    file exists yet -- an explicit setting is an instruction, not a guess), else
+    ``./.gcp-saved-tokens.json`` if that file actually exists, else ``None``.
+    """
+    configured = os.getenv(TOKEN_FILE_ENV)
+    if configured and configured.strip():
+        return os.path.abspath(configured.strip())
+    legacy = Path.cwd() / LEGACY_TOKEN_FILE
+    if legacy.exists():
+        return str(legacy.resolve())
+    return None
+
+
+def token_path_for(name: Optional[str] = None) -> str:
+    """The absolute path of the token file for account ``name``.
+
+    ``None`` resolves through :func:`resolve_account` first. The ``default``
+    account honours the legacy single-token location when one is configured.
+    """
+    resolved = resolve_account(name)
+    if resolved == DEFAULT_ACCOUNT:
+        legacy = legacy_token_path()
+        if legacy:
+            return legacy
+    return str((accounts_dir() / f"{resolved}.json").resolve())
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+
+def _known_names() -> List[str]:
+    """Every account with a token file on disk, plus ``default``, sorted."""
+    names = {DEFAULT_ACCOUNT}
+    directory = accounts_dir()
+    try:
+        entries = sorted(directory.glob("*.json"))
+    except OSError:  # pragma: no cover - unreadable config dir
+        entries = []
+    for entry in entries:
+        try:
+            names.add(validate_account_name(entry.stem))
+        except AccountError:
+            logger.debug("Ignoring token file with an unusable name: %s", entry)
+    ordered = sorted(names - {DEFAULT_ACCOUNT})
+    return [DEFAULT_ACCOUNT] + ordered
+
+
+def _inspect_token(path: str) -> Tuple[bool, Optional[str]]:
+    """Reports ``(usable, email)`` for a saved token file, without any network.
+
+    "Usable" means the file parses as an authorized-user token that either is
+    still valid or carries a refresh token we could exchange.
+    """
+    if not os.path.exists(path):
+        return False, None
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except (OSError, ValueError) as exc:
+        logger.debug("Token file %s is unreadable: %s", path, exc)
+        return False, None
+    if not isinstance(data, dict):
+        return False, None
+
+    email = data.get("account") or None
+
+    try:
+        from google.oauth2.credentials import Credentials
+
+        creds = Credentials.from_authorized_user_info(data)
+    except Exception as exc:
+        logger.debug("Token file %s does not parse as credentials: %s", path, exc)
+        return False, email
+
+    return bool(getattr(creds, "valid", False) or getattr(creds, "refresh_token", None)), email
+
+
+def account_exists(name: str) -> bool:
+    """True when a token file exists for ``name``."""
+    return os.path.exists(token_path_for(name))
+
+
+def list_accounts() -> List[AccountInfo]:
+    """Every known account, the default first.
+
+    ``default`` is always listed even when it has no token yet, so a fresh
+    install can still be told where its token would go.
+    """
+    default_name = resolve_account(None)
+    infos: List[AccountInfo] = []
+    for name in _known_names():
+        path = token_path_for(name)
+        valid, email = _inspect_token(path)
+        infos.append(
+            AccountInfo(
+                name=name,
+                token_path=path,
+                valid=valid,
+                email=email,
+                is_default=(name == default_name),
+            )
+        )
+    infos.sort(key=lambda info: (not info.is_default, info.name))
+    return infos
+
+
+def resolve_account(name: Optional[str] = None) -> str:
+    """Turns an optional account argument into a concrete account name.
+
+    With a name, validates and returns it. Without one:
+
+    1. ``$CALENDAR_MCP_DEFAULT_ACCOUNT`` when set;
+    2. ``default`` when that account has a token;
+    3. the sole account, when exactly one exists;
+    4. ``default``.
+
+    Raises:
+        AccountError: If an explicitly given name is malformed.
+    """
+    if name is not None and str(name).strip():
+        return validate_account_name(str(name))
+
+    configured = os.getenv(DEFAULT_ACCOUNT_ENV)
+    if configured and configured.strip():
+        return validate_account_name(configured)
+
+    default_path = legacy_token_path() or str((accounts_dir() / f"{DEFAULT_ACCOUNT}.json"))
+    if os.path.exists(default_path):
+        return DEFAULT_ACCOUNT
+
+    try:
+        existing = [entry.stem for entry in sorted(accounts_dir().glob("*.json"))]
+    except OSError:  # pragma: no cover - unreadable config dir
+        existing = []
+    if len(existing) == 1:
+        try:
+            return validate_account_name(existing[0])
+        except AccountError:  # pragma: no cover - odd file name
+            pass
+
+    return DEFAULT_ACCOUNT
+
+
+def describe_known_accounts() -> str:
+    """A short ``'default, work'`` listing for error messages."""
+    try:
+        return ", ".join(info.name for info in list_accounts()) or DEFAULT_ACCOUNT
+    except Exception:  # pragma: no cover - never let diagnostics raise
+        return DEFAULT_ACCOUNT
+
+
+__all__ = [
+    "APP_NAME",
+    "ACCOUNTS_SUBDIR",
+    "AccountError",
+    "AccountInfo",
+    "CONFIG_DIR_ENV",
+    "DEFAULT_ACCOUNT",
+    "DEFAULT_ACCOUNT_ENV",
+    "LEGACY_TOKEN_FILE",
+    "TOKEN_FILE_ENV",
+    "account_exists",
+    "accounts_dir",
+    "config_dir",
+    "describe_known_accounts",
+    "ensure_accounts_dir",
+    "ensure_config_dir",
+    "legacy_token_path",
+    "list_accounts",
+    "resolve_account",
+    "token_path_for",
+    "validate_account_name",
+]

--- a/calendar_mcp/audit.py
+++ b/calendar_mcp/audit.py
@@ -1,0 +1,641 @@
+"""Pure analysis behind the ``time_audit`` tool: where did the week go?
+
+Everything here is deterministic and offline. The Google layer is responsible
+for fetching raw events; :func:`event_from_google` (itself pure) reduces one of
+those to an :class:`AuditEvent`, and :func:`build_audit` turns a list of those
+plus the user's :class:`calendar_mcp.preferences.Preferences` into the report.
+
+Conventions used throughout:
+
+* Every interval is aware and half-open, ``start <= t < end``.
+* Meeting time is clipped to the requested window before it is counted, so an
+  event that straddles the edge only contributes the part inside.
+* Overlapping meetings are each counted in the totals (double-booking really
+  does inflate "meeting hours"), but the *share of working hours* is computed
+  from merged intervals, so it can never exceed 100%.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from .models import (
+    AuditBucket,
+    AuditExclusions,
+    AuditFocusBlock,
+    AuditPeriod,
+    AuditPerson,
+    AuditStretch,
+    TimeAuditResult,
+)
+from .preferences import Preferences, working_windows
+from .timeutil import Interval, clip_intervals, free_windows, iter_days, merge_intervals
+
+__all__ = [
+    "AuditEvent",
+    "DECLINED_STATUSES",
+    "SIZE_ONE_ON_ONE",
+    "SIZE_SMALL",
+    "SIZE_LARGE",
+    "SIZE_SOLO",
+    "build_audit",
+    "event_from_google",
+    "filter_events",
+    "hours_between",
+    "size_bucket",
+    "split_email_domain",
+]
+
+#: Response statuses that mean "this meeting does not cost me any time".
+DECLINED_STATUSES = frozenset({"declined"})
+
+SIZE_SOLO = "solo"
+SIZE_ONE_ON_ONE = "1:1"
+SIZE_SMALL = "small"
+SIZE_LARGE = "large"
+
+_WEEKDAY_NAMES = (
+    "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday",
+)
+
+
+# ---------------------------------------------------------------------------
+# The normalised event
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AuditEvent:
+    """One calendar entry, reduced to the fields the audit actually reads."""
+
+    start: datetime
+    end: datetime
+    summary: str = ""
+    attendees: List[str] = field(default_factory=list)
+    organizer: Optional[str] = None
+    self_email: Optional[str] = None
+    self_response_status: Optional[str] = None
+    transparency: Optional[str] = None
+    all_day: bool = False
+    recurring_event_id: Optional[str] = None
+    calendar_id: Optional[str] = None
+
+    @property
+    def is_declined(self) -> bool:
+        """True when the user turned this meeting down."""
+        return (self.self_response_status or "").strip().lower() in DECLINED_STATUSES
+
+    @property
+    def is_free(self) -> bool:
+        """True when the event is marked 'free' (transparent) and blocks nothing."""
+        return (self.transparency or "").strip().lower() == "transparent"
+
+    @property
+    def is_recurring(self) -> bool:
+        """True for an instance of a recurring series."""
+        return bool(self.recurring_event_id)
+
+    @property
+    def interval(self) -> Interval:
+        """The event as a ``(start, end)`` pair."""
+        return (self.start, self.end)
+
+    def others(self) -> List[str]:
+        """Attendee addresses other than the user's own: lower-cased, unique."""
+        mine = (self.self_email or "").strip().lower()
+        seen: List[str] = []
+        for raw in self.attendees:
+            email = (raw or "").strip().lower()
+            if not email or email == mine or email in seen:
+                continue
+            seen.append(email)
+        return seen
+
+
+def hours_between(start: datetime, end: datetime) -> float:
+    """Length of ``[start, end)`` in hours; never negative."""
+    return max(0.0, (end - start).total_seconds() / 3600.0)
+
+
+def _hours(intervals: Iterable[Interval]) -> float:
+    return sum(hours_between(start, end) for start, end in intervals)
+
+
+def _round(value: float, places: int = 2) -> float:
+    return round(float(value), places)
+
+
+def split_email_domain(email: str) -> str:
+    """The domain part of an address, lower-cased; ``''`` when there is none."""
+    _, _, domain = (email or "").strip().lower().partition("@")
+    return domain
+
+
+def size_bucket(attendee_count: int) -> str:
+    """Maps a headcount onto ``solo`` / ``1:1`` / ``small`` / ``large``.
+
+    ``attendee_count`` includes the user. Up to four people is small; more than
+    that is large. An event with no attendee list at all is a solo block.
+    """
+    if attendee_count <= 1:
+        return SIZE_SOLO
+    if attendee_count == 2:
+        return SIZE_ONE_ON_ONE
+    if attendee_count <= 4:
+        return SIZE_SMALL
+    return SIZE_LARGE
+
+
+# ---------------------------------------------------------------------------
+# Translation from the Google event shape
+# ---------------------------------------------------------------------------
+
+
+def _get(obj: Any, name: str, *aliases: str):
+    """Reads ``name`` off a pydantic model or a plain dict, trying aliases."""
+    for key in (name,) + aliases:
+        if isinstance(obj, dict):
+            if obj.get(key) is not None:
+                return obj[key]
+        else:
+            value = getattr(obj, key, None)
+            if value is not None:
+                return value
+    return None
+
+
+def _as_datetime(node: Any, tzinfo) -> Tuple[Optional[datetime], bool]:
+    """Turns a Google ``start``/``end`` node into ``(aware datetime, all_day)``."""
+    if node is None:
+        return None, False
+    stamp = _get(node, "dateTime", "date_time")
+    if stamp is not None:
+        if isinstance(stamp, str):
+            try:
+                stamp = datetime.fromisoformat(stamp.replace("Z", "+00:00"))
+            except ValueError:
+                return None, False
+        if stamp.tzinfo is None:
+            stamp = stamp.replace(tzinfo=tzinfo)
+        return stamp, False
+    day = _get(node, "date")
+    if day is None:
+        return None, False
+    if isinstance(day, str):
+        try:
+            day = date.fromisoformat(day)
+        except ValueError:
+            return None, False
+    if isinstance(day, datetime):
+        day = day.date()
+    return datetime.combine(day, datetime.min.time()).replace(tzinfo=tzinfo), True
+
+
+def event_from_google(raw: Any, tzinfo, calendar_id: Optional[str] = None) -> Optional[AuditEvent]:
+    """Reduces one Google event (pydantic model or API dict) to an :class:`AuditEvent`.
+
+    Args:
+        raw: A ``GoogleCalendarEvent`` or the equivalent API dict.
+        tzinfo: Zone used for all-day events and for naive timestamps.
+        calendar_id: Calendar the event came from, recorded on the result.
+
+    Returns:
+        The normalised event, or ``None`` when it has no usable start/end.
+    """
+    start, start_all_day = _as_datetime(_get(raw, "start"), tzinfo)
+    end, end_all_day = _as_datetime(_get(raw, "end"), tzinfo)
+    if start is None or end is None or end <= start:
+        return None
+
+    attendees: List[str] = []
+    self_email: Optional[str] = None
+    self_status: Optional[str] = None
+    for attendee in _get(raw, "attendees") or []:
+        email = _get(attendee, "email")
+        is_resource = _get(attendee, "resource") is True
+        if email and not is_resource:
+            attendees.append(str(email))
+        if _get(attendee, "self") is True:
+            if email:
+                self_email = str(email)
+            status = _get(attendee, "responseStatus", "response_status")
+            if status:
+                self_status = str(status)
+
+    organizer_node = _get(raw, "organizer")
+    organizer = _get(organizer_node, "email") if organizer_node is not None else None
+    if self_email is None and organizer_node is not None and _get(organizer_node, "self") is True:
+        self_email = str(organizer) if organizer else None
+
+    transparency = _get(raw, "transparency")
+    recurring = _get(raw, "recurringEventId", "recurring_event_id")
+
+    return AuditEvent(
+        start=start,
+        end=end,
+        summary=str(_get(raw, "summary") or ""),
+        attendees=attendees,
+        organizer=str(organizer) if organizer else None,
+        self_email=self_email,
+        self_response_status=self_status,
+        transparency=str(transparency) if transparency else None,
+        all_day=bool(start_all_day or end_all_day),
+        recurring_event_id=str(recurring) if recurring else None,
+        calendar_id=calendar_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Filtering
+# ---------------------------------------------------------------------------
+
+
+def filter_events(
+    events: Sequence[AuditEvent],
+    window: Interval,
+    include_all_day: bool = False,
+    include_declined: bool = False,
+    include_free: bool = False,
+) -> Tuple[List[AuditEvent], AuditExclusions]:
+    """Drops the events that do not count as meeting time.
+
+    Returns the kept events (still carrying their original, unclipped times)
+    alongside a tally of what was dropped and why. Reasons are tested in order,
+    so every dropped event is counted exactly once.
+    """
+    low, high = window
+    kept: List[AuditEvent] = []
+    dropped_all_day = dropped_declined = dropped_free = dropped_outside = 0
+    for event in events:
+        if event.end <= low or event.start >= high:
+            dropped_outside += 1
+            continue
+        if event.all_day and not include_all_day:
+            dropped_all_day += 1
+            continue
+        if event.is_declined and not include_declined:
+            dropped_declined += 1
+            continue
+        if event.is_free and not include_free:
+            dropped_free += 1
+            continue
+        kept.append(event)
+    kept.sort(key=lambda item: (item.start, item.end))
+    return kept, AuditExclusions(
+        all_day=dropped_all_day,
+        declined=dropped_declined,
+        marked_free=dropped_free,
+        outside_window=dropped_outside,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Period grouping
+# ---------------------------------------------------------------------------
+
+
+def _day_spans(window: Interval, tzinfo) -> List[Tuple[date, Interval]]:
+    """Every local day the window touches, with its clipped ``(start, end)``."""
+    low, high = window
+    spans: List[Tuple[date, Interval]] = []
+    for day in iter_days(low, high, tzinfo):
+        day_start = datetime.combine(day, datetime.min.time()).replace(tzinfo=tzinfo)
+        day_end = day_start + timedelta(days=1)
+        start, end = max(day_start, low), min(day_end, high)
+        if end > start:
+            spans.append((day, (start, end)))
+    return spans
+
+
+def _period_key(day: date, group_by: str) -> Tuple[Any, str]:
+    """Sort key and human label for the period ``day`` belongs to."""
+    if group_by == "day":
+        return (day, day.isoformat())
+    year, week = day.isocalendar()[0], day.isocalendar()[1]
+    return ((year, week), f"{year}-W{week:02d}")
+
+
+def _measure_period(
+    label: str,
+    span: Interval,
+    events: Sequence[AuditEvent],
+    prefs: Preferences,
+    tzinfo,
+) -> AuditPeriod:
+    """Meeting and working hours for one day or week."""
+    booked = clip_intervals((event.interval for event in events), span)
+    merged = merge_intervals(booked)
+    windows = working_windows(prefs, span[0], span[1], tzinfo=tzinfo)
+    working = _hours(windows)
+    in_working = sum(_hours(clip_intervals(merged, window)) for window in windows)
+    share = (in_working / working) if working > 0 else 0.0
+    return AuditPeriod(
+        period=label,
+        start=span[0].isoformat(),
+        end=span[1].isoformat(),
+        meeting_count=len(booked),
+        meeting_hours=_round(_hours(booked)),
+        working_hours=_round(working),
+        meeting_hours_in_working_hours=_round(in_working),
+        share_of_working_hours=_round(min(share, 1.0), 4),
+    )
+
+
+def _buckets(table: Dict[str, Tuple[int, float]], total_hours: float) -> List[AuditBucket]:
+    """Turns ``{label: (count, hours)}`` into sorted, share-annotated buckets."""
+    buckets = [
+        AuditBucket(
+            label=label,
+            meeting_count=count,
+            hours=_round(hours),
+            share_of_meeting_hours=_round((hours / total_hours) if total_hours > 0 else 0.0, 4),
+        )
+        for label, (count, hours) in table.items()
+    ]
+    buckets.sort(key=lambda bucket: (-bucket.hours, bucket.label))
+    return buckets
+
+
+def _back_to_back(
+    events: Sequence[AuditEvent],
+    window: Interval,
+    gap_minutes: int,
+    min_run: int = 3,
+) -> List[AuditStretch]:
+    """Runs of ``min_run`` or more meetings separated by less than ``gap_minutes``."""
+    spans = sorted(clip_intervals((event.interval for event in events), window))
+    if not spans:
+        return []
+    gap = timedelta(minutes=max(0, int(gap_minutes)))
+    stretches: List[AuditStretch] = []
+    run: List[Interval] = [spans[0]]
+
+    def close(current: List[Interval]) -> None:
+        if len(current) < min_run:
+            return
+        start = current[0][0]
+        end = max(item[1] for item in current)
+        stretches.append(
+            AuditStretch(
+                date=start.date().isoformat(),
+                start=start.isoformat(),
+                end=end.isoformat(),
+                meeting_count=len(current),
+                hours=_round(hours_between(start, end)),
+            )
+        )
+
+    for span in spans[1:]:
+        previous_end = max(item[1] for item in run)
+        if span[0] - previous_end < gap or span[0] <= previous_end:
+            run.append(span)
+        else:
+            close(run)
+            run = [span]
+    close(run)
+    return stretches
+
+
+def _focus_blocks(
+    events: Sequence[AuditEvent],
+    windows: Sequence[Interval],
+    buffer_minutes: int,
+    min_block_minutes: int,
+) -> List[Interval]:
+    """Free stretches inside the working windows that are long enough to use."""
+    busy = merge_intervals(event.interval for event in events)
+    minimum = timedelta(minutes=max(0, int(min_block_minutes)))
+    blocks: List[Interval] = []
+    for window in windows:
+        for free in free_windows(busy, window, buffer_minutes=buffer_minutes):
+            if free[1] - free[0] >= minimum:
+                blocks.append(free)
+    blocks.sort(key=lambda pair: pair[0])
+    return blocks
+
+
+# ---------------------------------------------------------------------------
+# Insights
+# ---------------------------------------------------------------------------
+
+
+def _insights(
+    share: float,
+    total_hours: float,
+    heaviest_weekday: Optional[Tuple[str, float]],
+    top_person: Optional[AuditPerson],
+    recurring_share: float,
+    back_to_back_count: int,
+    focus_hours: float,
+    longest_focus: Optional[AuditFocusBlock],
+) -> List[str]:
+    """Three to five plain-English takeaways, most actionable first."""
+    if total_hours <= 0:
+        return ["No meetings in this window -- all of your working time was unbooked."]
+    lines = [
+        f"{share * 100:.0f}% of your working hours went to meetings "
+        f"({total_hours:.1f}h in total)."
+    ]
+    if heaviest_weekday and heaviest_weekday[1] > 0:
+        name, hours = heaviest_weekday
+        lines.append(f"{name}s are your heaviest day ({hours:.1f}h of meetings).")
+    if top_person is not None:
+        lines.append(
+            f"Most time with {top_person.email}: {top_person.hours:.1f}h "
+            f"across {top_person.meeting_count} meetings."
+        )
+    if back_to_back_count:
+        lines.append(
+            f"{back_to_back_count} back-to-back stretch"
+            f"{'' if back_to_back_count == 1 else 'es'} of three or more meetings "
+            "with no real gap."
+        )
+    elif recurring_share > 0:
+        lines.append(f"{recurring_share * 100:.0f}% of your meeting time is recurring.")
+    if len(lines) < 5:
+        if longest_focus is not None:
+            lines.append(
+                f"{focus_hours:.1f}h of focus time is left, the longest single block "
+                f"being {longest_focus.hours:.1f}h."
+            )
+        else:
+            lines.append("No free block survived long enough to count as focus time.")
+    return lines[:5]
+
+
+# ---------------------------------------------------------------------------
+# The report
+# ---------------------------------------------------------------------------
+
+
+def build_audit(
+    events: Sequence[AuditEvent],
+    window: Interval,
+    prefs: Preferences,
+    tzinfo,
+    group_by: str = "week",
+    calendar_ids: Optional[Sequence[str]] = None,
+    include_all_day: bool = False,
+    include_declined: bool = False,
+    back_to_back_gap_minutes: Optional[int] = None,
+    top_people: int = 10,
+) -> TimeAuditResult:
+    """Computes the whole time audit from already-normalised events.
+
+    Args:
+        events: Normalised events; anything outside ``window`` is ignored.
+        window: The aware ``(time_min, time_max)`` range being audited.
+        prefs: Working hours, lunch, buffer and focus-block minimum.
+        tzinfo: Zone the report's days and working hours are expressed in.
+        group_by: ``'day'`` or ``'week'`` for the per-period breakdown.
+        calendar_ids: Calendars the events came from, echoed in the result.
+        include_all_day: Count all-day events as meeting time.
+        include_declined: Count meetings the user declined.
+        back_to_back_gap_minutes: Gap below which two meetings count as
+            back-to-back. Defaults to ``prefs.buffer_minutes``, or 5 minutes
+            when no buffer is configured.
+        top_people: How many people to list in ``top_people``.
+
+    Returns:
+        The populated :class:`calendar_mcp.models.TimeAuditResult`.
+    """
+    group = "day" if str(group_by).lower() == "day" else "week"
+    kept, exclusions = filter_events(
+        events, window, include_all_day=include_all_day, include_declined=include_declined
+    )
+
+    booked = clip_intervals((event.interval for event in kept), window)
+    total_hours = _hours(booked)
+    merged = merge_intervals(booked)
+
+    windows = working_windows(prefs, window[0], window[1], tzinfo=tzinfo)
+    working_hours = _hours(windows)
+    in_working = sum(_hours(clip_intervals(merged, window_)) for window_ in windows)
+    overall_share = min(in_working / working_hours, 1.0) if working_hours > 0 else 0.0
+
+    # -- per day, then per requested period --------------------------------
+    spans = _day_spans(window, tzinfo)
+    day_periods = [
+        _measure_period(day.isoformat(), span, kept, prefs, tzinfo) for day, span in spans
+    ]
+
+    if group == "day":
+        periods = day_periods
+    else:
+        grouped: Dict[Any, Tuple[str, datetime, datetime]] = {}
+        for day, span in spans:
+            key, label = _period_key(day, group)
+            if key in grouped:
+                _, start, end = grouped[key]
+                grouped[key] = (label, min(start, span[0]), max(end, span[1]))
+            else:
+                grouped[key] = (label, span[0], span[1])
+        periods = [
+            _measure_period(label, (start, end), kept, prefs, tzinfo)
+            for _, (label, start, end) in sorted(grouped.items(), key=lambda item: item[0])
+        ]
+
+    longest_day = max(day_periods, key=lambda period: period.meeting_hours, default=None)
+    if longest_day is not None and longest_day.meeting_hours <= 0:
+        longest_day = None
+    busiest_period = max(periods, key=lambda period: period.meeting_hours, default=None)
+    if busiest_period is not None and busiest_period.meeting_hours <= 0:
+        busiest_period = None
+
+    weekday_hours: Dict[int, float] = {}
+    for day, span in spans:
+        clipped = clip_intervals((event.interval for event in kept), span)
+        weekday_hours[day.weekday()] = weekday_hours.get(day.weekday(), 0.0) + _hours(clipped)
+    heaviest_weekday: Optional[Tuple[str, float]] = None
+    if weekday_hours:
+        index = max(weekday_hours, key=lambda key: weekday_hours[key])
+        if weekday_hours[index] > 0:
+            heaviest_weekday = (_WEEKDAY_NAMES[index], weekday_hours[index])
+
+    # -- breakdowns --------------------------------------------------------
+    by_size: Dict[str, Tuple[int, float]] = {}
+    by_domain: Dict[str, Tuple[int, float]] = {}
+    by_recurrence: Dict[str, Tuple[int, float]] = {}
+    people: Dict[str, Tuple[int, float]] = {}
+
+    def add(table: Dict[str, Tuple[int, float]], key: str, hours: float) -> None:
+        count, total = table.get(key, (0, 0.0))
+        table[key] = (count + 1, total + hours)
+
+    for event in kept:
+        hours = _hours(clip_intervals([event.interval], window))
+        if hours <= 0:
+            continue
+        headcount = len({email.strip().lower() for email in event.attendees if email})
+        add(by_size, size_bucket(headcount), hours)
+        add(by_recurrence, "recurring" if event.is_recurring else "one-off", hours)
+        others = event.others()
+        for email in others:
+            add(people, email, hours)
+        for domain in sorted({split_email_domain(email) for email in others if "@" in email}):
+            add(by_domain, domain, hours)
+
+    ranked = sorted(people.items(), key=lambda item: (-item[1][1], item[0]))
+    top = [
+        AuditPerson(email=email, meeting_count=count, hours=_round(hours))
+        for email, (count, hours) in ranked[: max(0, int(top_people))]
+    ]
+
+    # -- back-to-back and focus -------------------------------------------
+    gap = back_to_back_gap_minutes
+    if gap is None:
+        gap = prefs.buffer_minutes or 5
+    stretches = _back_to_back(kept, window, int(gap))
+
+    blocks = _focus_blocks(kept, windows, prefs.buffer_minutes, prefs.min_focus_block_minutes)
+    focus = [
+        AuditFocusBlock(
+            start=start.isoformat(),
+            end=end.isoformat(),
+            hours=_round(hours_between(start, end)),
+        )
+        for start, end in blocks
+    ]
+    largest = sorted(focus, key=lambda block: -block.hours)[:5]
+
+    recurring_hours = by_recurrence.get("recurring", (0, 0.0))[1]
+    recurring_share = (recurring_hours / total_hours) if total_hours > 0 else 0.0
+
+    return TimeAuditResult(
+        time_min=window[0].isoformat(),
+        time_max=window[1].isoformat(),
+        timezone=str(getattr(tzinfo, "key", tzinfo)),
+        group_by=group,
+        calendar_ids=list(calendar_ids or []),
+        total_meeting_hours=_round(total_hours),
+        total_meeting_count=len(kept),
+        working_hours_available=_round(working_hours),
+        meeting_hours_in_working_hours=_round(in_working),
+        share_of_working_hours=_round(overall_share, 4),
+        periods=periods,
+        by_size=_buckets(by_size, total_hours),
+        by_domain=_buckets(by_domain, total_hours),
+        by_recurrence=_buckets(by_recurrence, total_hours),
+        top_people=top,
+        longest_meeting_day=longest_day,
+        busiest_period=busiest_period,
+        back_to_back_count=len(stretches),
+        back_to_back_hours=_round(sum(item.hours for item in stretches)),
+        back_to_back_stretches=stretches,
+        focus_hours_available=_round(sum(block.hours for block in focus)),
+        focus_block_count=len(focus),
+        largest_focus_blocks=largest,
+        excluded=exclusions,
+        insights=_insights(
+            overall_share,
+            total_hours,
+            heaviest_weekday,
+            top[0] if top else None,
+            recurring_share,
+            len(stretches),
+            _round(sum(block.hours for block in focus)),
+            largest[0] if largest else None,
+        ),
+    )

--- a/calendar_mcp/auth.py
+++ b/calendar_mcp/auth.py
@@ -9,6 +9,12 @@ run ``calendar-mcp auth`` if that is not possible.
 
 Set ``CALENDAR_MCP_ALLOW_BROWSER_AUTH=1`` (or pass ``allow_browser=True``, which
 the ``calendar-mcp auth`` subcommand does) to permit the interactive flow.
+
+Every function here takes an explicit ``path`` for the token file, so one
+process can hold several signed-in accounts at once. Omitting it falls back to
+:func:`token_file_path` -- the single legacy location -- which keeps the old
+signatures working unchanged. Callers that care about named accounts should ask
+:func:`calendar_mcp.accounts.token_path_for` for the path instead.
 """
 
 import logging
@@ -51,7 +57,12 @@ def client_secret() -> Optional[str]:
 
 
 def token_file_path() -> str:
-    """Absolute-or-relative path of the file the OAuth token is cached in."""
+    """The legacy single-account token path: ``$TOKEN_FILE_PATH`` or the default.
+
+    This is the fallback for every ``path`` argument in this module, and the
+    ``default`` account's token file when it is configured. For a named account
+    use :func:`calendar_mcp.accounts.token_path_for`.
+    """
     return os.getenv("TOKEN_FILE_PATH", DEFAULT_TOKEN_FILE)
 
 
@@ -120,13 +131,23 @@ def save_credentials(creds: Credentials, path: Optional[str] = None) -> str:
     return target
 
 
-def load_credentials(refresh: bool = True) -> Optional[Credentials]:
-    """Loads the saved token, refreshing it when expired. Never opens a browser.
+def load_credentials(
+    refresh: bool = True,
+    path: Optional[str] = None,
+) -> Optional[Credentials]:
+    """Loads a saved token, refreshing it when expired. Never opens a browser.
 
-    Returns valid :class:`Credentials`, or ``None`` when there is no usable
-    saved token.
+    Args:
+        refresh: Exchange an expired token for a fresh one (and re-save it).
+        path: Token file to read. Defaults to :func:`token_file_path`, i.e. the
+            legacy single-account location; pass
+            :func:`calendar_mcp.accounts.token_path_for` for a named account.
+
+    Returns:
+        Valid :class:`Credentials`, or ``None`` when there is no usable saved
+        token at ``path``.
     """
-    path = token_file_path()
+    path = path or token_file_path()
     if not os.path.exists(path):
         logger.info("No saved token at %s", path)
         return None
@@ -156,8 +177,17 @@ def load_credentials(refresh: bool = True) -> Optional[Credentials]:
     return None
 
 
-def run_oauth_flow(open_browser: bool = True) -> Credentials:
+def run_oauth_flow(
+    open_browser: bool = True,
+    path: Optional[str] = None,
+) -> Credentials:
     """Runs the interactive installed-app OAuth flow and saves the token.
+
+    Args:
+        open_browser: Open the consent screen automatically. False prints the
+            URL instead, for a headless terminal.
+        path: Where to save the resulting token. Defaults to
+            :func:`token_file_path`.
 
     Raises:
         AuthError: If the client is not configured or the flow does not complete.
@@ -183,23 +213,30 @@ def run_oauth_flow(open_browser: bool = True) -> Credentials:
     if not creds or not creds.valid:
         raise AuthError("The Google OAuth flow did not produce valid credentials.")
 
-    save_credentials(creds)
+    save_credentials(creds, path)
     return creds
 
 
-def get_credentials(allow_browser: Optional[bool] = None) -> Credentials:
+def get_credentials(
+    allow_browser: Optional[bool] = None,
+    path: Optional[str] = None,
+) -> Credentials:
     """Returns valid Google credentials.
 
     Args:
         allow_browser: Permit the interactive OAuth flow. ``None`` (the default)
             means "consult the ``CALENDAR_MCP_ALLOW_BROWSER_AUTH`` env var",
             which is off by default so an MCP server never blocks on a browser.
+        path: Token file to load and, if the browser flow runs, save to.
+            Defaults to :func:`token_file_path`.
 
     Raises:
         AuthError: If no valid token exists and the browser flow is not allowed
             (or fails). The message tells the user how to fix it.
     """
-    creds = load_credentials()
+    target = path or token_file_path()
+
+    creds = load_credentials(path=target)
     if creds is not None:
         return creds
 
@@ -209,17 +246,17 @@ def get_credentials(allow_browser: Optional[bool] = None) -> Credentials:
     if not allow_browser:
         raise AuthError(
             "No valid Google Calendar token was found at "
-            f"'{token_file_path()}'. Run 'calendar-mcp auth' once in a terminal to "
+            f"'{target}'. Run 'calendar-mcp auth' once in a terminal to "
             f"sign in, or set {ALLOW_BROWSER_AUTH_ENV}=1 to let the server open a "
             "browser window itself."
         )
 
-    return run_oauth_flow()
+    return run_oauth_flow(path=target)
 
 
-def has_valid_token() -> bool:
-    """True when a saved (or refreshable) token is currently usable."""
+def has_valid_token(path: Optional[str] = None) -> bool:
+    """True when a saved (or refreshable) token at ``path`` is currently usable."""
     try:
-        return load_credentials() is not None
+        return load_credentials(path=path) is not None
     except Exception:  # pragma: no cover - defensive
         return False

--- a/calendar_mcp/cli.py
+++ b/calendar_mcp/cli.py
@@ -3,6 +3,8 @@
     calendar-mcp                       # serve MCP over stdio (the default)
     calendar-mcp --transport http      # serve MCP over streamable HTTP
     calendar-mcp auth                  # sign in to Google in a browser, once
+    calendar-mcp auth --account work   # sign in a second, named account
+    calendar-mcp accounts              # list the accounts and their token files
     calendar-mcp check                 # verify the saved token works
 
 Logging never goes to stdout: in stdio mode stdout is the MCP protocol channel.
@@ -118,13 +120,15 @@ def build_parser() -> argparse.ArgumentParser:
             "  calendar-mcp                      serve over stdio (what MCP clients launch)\n"
             "  calendar-mcp --transport http --port 8000\n"
             "  calendar-mcp auth                 one-time Google sign-in in a browser\n"
+            "  calendar-mcp auth --account work  sign in an additional named account\n"
+            "  calendar-mcp accounts             list the known accounts\n"
             "  calendar-mcp check                verify the saved token still works\n"
         ),
     )
     parser.add_argument("--version", action="version", version=f"{PROG} {__version__}")
     _add_serve_arguments(parser)
 
-    subparsers = parser.add_subparsers(dest="command", metavar="{serve,auth,check}")
+    subparsers = parser.add_subparsers(dest="command", metavar="{serve,auth,accounts,check}")
 
     serve = subparsers.add_parser("serve", help="Serve MCP (the default when no subcommand is given).")
     _add_serve_arguments(serve)
@@ -139,6 +143,25 @@ def build_parser() -> argparse.ArgumentParser:
         help="Print the authorization URL instead of opening a browser.",
     )
     auth_cmd.add_argument(
+        "--account",
+        default=None,
+        metavar="NAME",
+        help="Account to sign in, e.g. 'work'. Omit for the default account. Each "
+        "account keeps its own token, so several Google accounts can be signed "
+        "in at once.",
+    )
+    auth_cmd.add_argument(
+        "--log-level",
+        default="WARNING",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Logging verbosity on stderr (default: WARNING).",
+    )
+
+    accounts_cmd = subparsers.add_parser(
+        "accounts",
+        help="List the known accounts, their token files and whether each is signed in.",
+    )
+    accounts_cmd.add_argument(
         "--log-level",
         default="WARNING",
         choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
@@ -148,6 +171,12 @@ def build_parser() -> argparse.ArgumentParser:
     check = subparsers.add_parser(
         "check",
         help="Report whether a valid Google token exists, and list the calendars.",
+    )
+    check.add_argument(
+        "--account",
+        default=None,
+        metavar="NAME",
+        help="Account to check. Omit for the default account.",
     )
     check.add_argument(
         "--log-level",
@@ -173,9 +202,19 @@ def command_serve(args: argparse.Namespace) -> int:
     return 0
 
 
+def _resolve_account(args: argparse.Namespace) -> Optional[str]:
+    """The account named on the command line, validated. ``None`` for the default."""
+    from . import accounts
+
+    requested = getattr(args, "account", None)
+    if requested is None:
+        return None
+    return accounts.validate_account_name(requested)
+
+
 def command_auth(args: argparse.Namespace) -> int:
     """Runs the interactive OAuth flow and reports where the token landed."""
-    from . import auth
+    from . import accounts, auth
 
     if not auth.client_id() or not auth.client_secret():
         print(
@@ -186,37 +225,87 @@ def command_auth(args: argparse.Namespace) -> int:
         )
         return 1
 
+    try:
+        account = accounts.resolve_account(_resolve_account(args))
+    except accounts.AccountError as exc:
+        print(f"{PROG}: {exc}", file=sys.stderr)
+        return 1
+
+    token_path = accounts.token_path_for(account)
+    # A named account's token lands under the config directory, which may not
+    # exist yet; the legacy single-token path is created by auth.save_credentials.
+    if account != accounts.DEFAULT_ACCOUNT or not accounts.legacy_token_path():
+        accounts.ensure_accounts_dir()
+
     print(f"Opening a browser to authorize {PROG} against your Google Calendar...")
+    print(f"Account: {account}")
+    print(f"Token will be saved to: {os.path.abspath(token_path)}")
     print(f"Redirect URI in use: {auth.redirect_uri()}")
     print(
         "A 'Desktop app' OAuth client accepts http://localhost on any port, so there\n"
         "is nothing to register; set OAUTH_CALLBACK_PORT if this port is taken.\n"
     )
     try:
-        auth.run_oauth_flow(open_browser=not args.no_browser)
+        auth.run_oauth_flow(open_browser=not args.no_browser, path=token_path)
     except auth.AuthError as exc:
         print(f"{PROG}: {exc}", file=sys.stderr)
         return 1
 
-    path = os.path.abspath(auth.token_file_path())
-    print(f"\nAuthorized. Token saved to {path}")
+    print(f"\nAuthorized. Token saved to {os.path.abspath(token_path)}")
     print(f"You can now run '{PROG}' (or point your MCP client at it).")
+    if account != accounts.DEFAULT_ACCOUNT:
+        print(
+            f"Pass account='{account}' to any tool, or set "
+            f"CALENDAR_MCP_DEFAULT_ACCOUNT={account} to make it the default."
+        )
+    return 0
+
+
+def command_accounts(args: argparse.Namespace) -> int:
+    """Lists the known accounts, their token files and their sign-in state."""
+    from . import accounts
+
+    print(f"Config directory: {accounts.config_dir()}")
+    infos = accounts.list_accounts()
+    print(f"\nAccounts ({len(infos)}):")
+    for info in infos:
+        marker = " (default)" if info.is_default else ""
+        state = "signed in" if info.valid else "not signed in"
+        who = f" <{info.email}>" if info.email else ""
+        print(f"  {info.name}{marker}{who} -- {state}")
+        print(f"      token: {info.token_path}")
+
+    if not any(info.valid for info in infos):
+        print(
+            f"\nNo account is signed in yet. Run '{PROG} auth' "
+            "(add --account NAME for an additional one).",
+            file=sys.stderr,
+        )
+        return 1
     return 0
 
 
 def command_check(args: argparse.Namespace) -> int:
     """Reports token status and, when possible, lists the user's calendars."""
-    from . import auth, calendar_actions
+    from . import accounts, auth, calendar_actions
 
-    token_path = os.path.abspath(auth.token_file_path())
+    try:
+        account = accounts.resolve_account(_resolve_account(args))
+    except accounts.AccountError as exc:
+        print(f"{PROG}: {exc}", file=sys.stderr)
+        return 1
+
+    token_path = os.path.abspath(accounts.token_path_for(account))
+    print(f"Account: {account}")
     print(f"Token file: {token_path}")
     print(f"Client ID configured: {'yes' if auth.client_id() else 'no'}")
     print(f"Client secret configured: {'yes' if auth.client_secret() else 'no'}")
 
-    creds = auth.load_credentials()
+    creds = auth.load_credentials(path=token_path)
     if creds is None:
+        suffix = "" if account == accounts.DEFAULT_ACCOUNT else f" --account {account}"
         print(
-            f"\nNo valid Google Calendar token.\nRun '{PROG} auth' to sign in.",
+            f"\nNo valid Google Calendar token.\nRun '{PROG} auth{suffix}' to sign in.",
             file=sys.stderr,
         )
         return 1
@@ -255,6 +344,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     try:
         if command == "auth":
             return command_auth(args)
+        if command == "accounts":
+            return command_accounts(args)
         if command == "check":
             return command_check(args)
         return command_serve(args)

--- a/calendar_mcp/models.py
+++ b/calendar_mcp/models.py
@@ -83,6 +83,7 @@ class GoogleCalendarEvent(BaseModel):
     description: Optional[str] = Field(None, description="Description of the event. Optional.")
     location: Optional[str] = Field(None, description="Geographic location of the event. Optional.")
     color_id: Optional[str] = Field(None, alias='colorId', description="Color of the event. Optional.")
+    transparency: Optional[str] = Field(None, description="Whether the event blocks time on the calendar: 'opaque' (busy, the default) or 'transparent' (free).")
     creator: Optional[EventCreator] = Field(None, description="The creator of the event. Read-only.")
     organizer: Optional[EventOrganizer] = Field(None, description="The organizer of the event.")
     start: Optional[EventDateTime] = Field(None, description="The start time of the event.")
@@ -511,3 +512,340 @@ class ProjectedEventsResult(BaseModel):
     occurrences: List[ProjectedOccurrence] = Field(
         default_factory=list, description="Computed occurrences, earliest first."
     )
+
+
+# ---------------------------------------------------------------------------
+# Accounts
+#
+# calendar-mcp can hold a signed-in token per named account ("default", "work",
+# "personal", ...). These models are the structured output of the
+# ``list_accounts`` tool; the account bookkeeping itself lives in
+# :mod:`calendar_mcp.accounts`.
+# ---------------------------------------------------------------------------
+
+
+class AccountInfo(BaseModel):
+    """One named Google account calendar-mcp holds (or could hold) a token for."""
+    name: str = Field(..., description="Account name. Pass this as the 'account' argument of any tool.")
+    token_path: str = Field(..., description="Absolute path of the file this account's OAuth token is cached in.")
+    valid: bool = Field(
+        False,
+        description="True when a usable saved token exists. False means 'calendar-mcp auth --account <name>' is needed.",
+    )
+    email: Optional[str] = Field(
+        None, description="Google account address, when the saved token records one."
+    )
+    is_default: bool = Field(
+        False, description="True for the account used when a tool's 'account' argument is omitted."
+    )
+
+
+class AccountListResult(BaseModel):
+    """Result of the list_accounts tool."""
+    count: int = Field(..., description="Number of known accounts.")
+    default_account: str = Field(..., description="Account used when 'account' is omitted.")
+    config_dir: str = Field(..., description="Directory holding the account tokens and preferences.")
+    accounts: List[AccountInfo] = Field(
+        default_factory=list, description="Known accounts, the default one first."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Time audit  (appended by the time_audit agent -- keep this block together)
+#
+# Structured output of the ``time_audit`` tool. The maths that fills these in
+# lives in :mod:`calendar_mcp.audit`; nothing here touches Google or the disk.
+# All durations are hours (float, rounded to 2dp) and all shares are fractions
+# in 0..1 rather than percentages.
+# ---------------------------------------------------------------------------
+
+
+class AuditPeriod(BaseModel):
+    """Meeting load for one day or one ISO week."""
+    period: str = Field(..., description="Period label: 'YYYY-MM-DD' for a day, 'YYYY-Www' for a week.")
+    start: str = Field(..., description="Inclusive start of the period, ISO 8601.")
+    end: str = Field(..., description="Exclusive end of the period, ISO 8601.")
+    meeting_count: int = Field(0, description="Meetings that overlap this period.")
+    meeting_hours: float = Field(0.0, description="Total meeting hours inside this period.")
+    working_hours: float = Field(0.0, description="Working hours available in this period, lunch removed.")
+    meeting_hours_in_working_hours: float = Field(
+        0.0, description="Meeting hours that fall inside the working hours (overlaps merged)."
+    )
+    share_of_working_hours: float = Field(
+        0.0, description="meeting_hours_in_working_hours / working_hours, 0..1."
+    )
+
+
+class AuditBucket(BaseModel):
+    """One slice of the meeting time: a size class, a domain, or recurring/one-off."""
+    label: str = Field(..., description="Bucket name, e.g. '1:1', 'large', 'corp.com', 'recurring'.")
+    meeting_count: int = Field(0, description="Meetings counted in this bucket.")
+    hours: float = Field(0.0, description="Meeting hours in this bucket.")
+    share_of_meeting_hours: float = Field(
+        0.0, description="Bucket hours / total meeting hours, 0..1. Domain buckets can sum above 1."
+    )
+
+
+class AuditPerson(BaseModel):
+    """How much time the user spent in meetings with one other person."""
+    email: str = Field(..., description="Attendee address, lower-cased.")
+    meeting_count: int = Field(0, description="Meetings shared with this person.")
+    hours: float = Field(0.0, description="Meeting hours shared with this person.")
+
+
+class AuditStretch(BaseModel):
+    """A run of three or more meetings with no usable gap between them."""
+    date: str = Field(..., description="Local date the stretch starts on, 'YYYY-MM-DD'.")
+    start: str = Field(..., description="Start of the first meeting, ISO 8601.")
+    end: str = Field(..., description="End of the last meeting, ISO 8601.")
+    meeting_count: int = Field(0, description="Meetings in the stretch.")
+    hours: float = Field(0.0, description="Wall-clock length of the whole stretch.")
+
+
+class AuditFocusBlock(BaseModel):
+    """An unbooked stretch of working time long enough to be useful."""
+    start: str = Field(..., description="Start of the free block, ISO 8601.")
+    end: str = Field(..., description="End of the free block, ISO 8601.")
+    hours: float = Field(0.0, description="Length of the block in hours.")
+
+
+class AuditExclusions(BaseModel):
+    """Events that were seen but deliberately not counted as meeting time."""
+    all_day: int = Field(0, description="All-day events skipped (pass include_all_day to count them).")
+    declined: int = Field(0, description="Meetings the user declined.")
+    marked_free: int = Field(0, description="Events marked 'free' rather than 'busy'.")
+    outside_window: int = Field(0, description="Events that did not overlap the requested window.")
+
+
+class TimeAuditResult(BaseModel):
+    """Result of the time_audit tool: where the user's time actually went."""
+    time_min: str = Field(..., description="Inclusive start of the audited window, ISO 8601.")
+    time_max: str = Field(..., description="Exclusive end of the audited window, ISO 8601.")
+    timezone: str = Field(..., description="Timezone the days, weeks and working hours are expressed in.")
+    group_by: str = Field("week", description="Period grouping used: 'day' or 'week'.")
+    calendar_ids: List[str] = Field(default_factory=list, description="Calendars the events came from.")
+
+    total_meeting_hours: float = Field(0.0, description="Total meeting hours in the window; overlaps counted twice.")
+    total_meeting_count: int = Field(0, description="Meetings counted.")
+    working_hours_available: float = Field(0.0, description="Working hours in the window, lunch removed.")
+    meeting_hours_in_working_hours: float = Field(
+        0.0, description="Meeting hours inside the working hours, overlaps merged."
+    )
+    share_of_working_hours: float = Field(
+        0.0, description="Fraction of the working hours spent in meetings, 0..1."
+    )
+
+    periods: List[AuditPeriod] = Field(default_factory=list, description="Per-day or per-week breakdown, earliest first.")
+    by_size: List[AuditBucket] = Field(
+        default_factory=list,
+        description="Meeting time by headcount: 'solo', '1:1', 'small' (<=4), 'large'.",
+    )
+    by_domain: List[AuditBucket] = Field(
+        default_factory=list,
+        description="Meeting time by attendee email domain. A meeting with two domains counts in both.",
+    )
+    by_recurrence: List[AuditBucket] = Field(
+        default_factory=list, description="Meeting time split into 'recurring' and 'one-off'."
+    )
+    top_people: List[AuditPerson] = Field(
+        default_factory=list, description="People the user shared the most meeting hours with, most first."
+    )
+
+    longest_meeting_day: Optional[AuditPeriod] = Field(
+        None, description="The single heaviest day, regardless of group_by. None when nothing was booked."
+    )
+    busiest_period: Optional[AuditPeriod] = Field(
+        None, description="The heaviest entry of 'periods'. None when nothing was booked."
+    )
+
+    back_to_back_count: int = Field(0, description="Runs of three or more meetings with no usable gap.")
+    back_to_back_hours: float = Field(0.0, description="Total wall-clock hours those runs cover.")
+    back_to_back_stretches: List[AuditStretch] = Field(
+        default_factory=list, description="The individual back-to-back runs, earliest first."
+    )
+
+    focus_hours_available: float = Field(
+        0.0, description="Unbooked working hours in blocks at least min_focus_block_minutes long."
+    )
+    focus_block_count: int = Field(0, description="Number of such blocks.")
+    largest_focus_blocks: List[AuditFocusBlock] = Field(
+        default_factory=list, description="The five longest free blocks, longest first."
+    )
+
+    excluded: AuditExclusions = Field(
+        default_factory=AuditExclusions, description="What was skipped and why."
+    )
+    insights: List[str] = Field(
+        default_factory=list, description="Three to five plain-English takeaways."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scheduling: focus time, conflicts and reschedule suggestions
+#
+# Structured output for the tools in ``calendar_mcp.tools.focus`` and
+# ``calendar_mcp.tools.conflicts``. The reasoning behind them lives in
+# :mod:`calendar_mcp.scheduling`, which is pure; these models are only the
+# shape it is reported in. Every timestamp is an ISO 8601 string, expressed in
+# the user's preferred timezone (``preferences.timezone``) when they have set
+# one, and otherwise in the calendar's own.
+# ---------------------------------------------------------------------------
+
+
+class FocusBlock(BaseModel):
+    """One uninterrupted stretch of working time with nothing booked in it."""
+    start: str = Field(..., description="Block start, ISO 8601.")
+    end: str = Field(..., description="Block end, ISO 8601.")
+    duration_minutes: float = Field(..., description="Length of the block in minutes.")
+    date: str = Field(..., description="Local date the block starts on, YYYY-MM-DD.")
+    weekday: str = Field(..., description="Local weekday the block starts on, e.g. 'Thursday'.")
+
+
+class FocusTimeResult(BaseModel):
+    """Result of the find_focus_time tool: when this person could actually think."""
+    time_min: str = Field(..., description="Start of the searched window, ISO 8601.")
+    time_max: str = Field(..., description="End of the searched window, ISO 8601.")
+    timezone: str = Field(..., description="Timezone the blocks are expressed in.")
+    calendar_ids: List[str] = Field(
+        default_factory=list, description="Calendars whose busy time was subtracted."
+    )
+    hours_needed: float = Field(0.0, description="Focus hours the caller asked for.")
+    total_free_hours: float = Field(0.0, description="Total focus hours available in the window.")
+    satisfiable: bool = Field(
+        False, description="True when total_free_hours covers hours_needed."
+    )
+    min_block_minutes: int = Field(
+        0, description="Shortest stretch counted, from preferences.min_focus_block_minutes."
+    )
+    buffer_minutes: int = Field(
+        0, description="Gap left around each meeting, from preferences.buffer_minutes."
+    )
+    count: int = Field(0, description="Number of blocks returned.")
+    blocks: List[FocusBlock] = Field(
+        default_factory=list, description="Usable blocks, longest first, then earliest."
+    )
+    message: str = Field("", description="One-line human-readable summary.")
+
+
+class BlockedFocusEvent(BaseModel):
+    """One focus block, as booked (or as it would be booked in a dry run)."""
+    start: str = Field(..., description="Block start, ISO 8601.")
+    end: str = Field(..., description="Block end, ISO 8601.")
+    duration_minutes: float = Field(..., description="Length of the block in minutes.")
+    summary: str = Field(..., description="Title the event was given.")
+    created: bool = Field(False, description="False in a dry run: nothing was written.")
+    event_id: Optional[str] = Field(None, description="ID of the created event; null in a dry run.")
+    html_link: Optional[str] = Field(None, description="Link to the event in Google Calendar.")
+
+
+class BlockedFocusResult(BaseModel):
+    """Result of the block_focus_time tool."""
+    calendar_id: str = Field(..., description="Calendar the blocks were booked on.")
+    time_min: str = Field(..., description="Start of the searched window, ISO 8601.")
+    time_max: str = Field(..., description="End of the searched window, ISO 8601.")
+    timezone: str = Field(..., description="Timezone the blocks are expressed in.")
+    dry_run: bool = Field(False, description="True when nothing was written to the calendar.")
+    hours_needed: float = Field(0.0, description="Focus hours the caller asked for.")
+    hours_booked: float = Field(0.0, description="Focus hours actually covered by these blocks.")
+    total_free_hours: float = Field(
+        0.0, description="Focus hours that were available in the window."
+    )
+    satisfied: bool = Field(False, description="True when hours_booked covers hours_needed.")
+    count: int = Field(0, description="Number of blocks.")
+    events: List[BlockedFocusEvent] = Field(
+        default_factory=list, description="The blocks, earliest first."
+    )
+    message: str = Field("", description="One-line human-readable summary.")
+
+
+class ConflictEventRef(BaseModel):
+    """Enough of an event to recognise it in a conflict report and act on it."""
+    account: str = Field(..., description="Account the event was read from.")
+    calendar_id: str = Field(..., description="Calendar the event lives on.")
+    event_id: Optional[str] = Field(None, description="Event ID; pass it to move_event or update_event.")
+    summary: Optional[str] = Field(None, description="Event title.")
+    start: str = Field(..., description="Event start, ISO 8601.")
+    end: str = Field(..., description="Event end, ISO 8601.")
+    all_day: bool = Field(False, description="True for an all-day event.")
+
+
+class EventConflict(BaseModel):
+    """Two events that are booked over each other."""
+    overlap_minutes: float = Field(..., description="Minutes the two events share.")
+    same_calendar: bool = Field(False, description="True when both events are on one calendar.")
+    same_account: bool = Field(False, description="True when both events belong to one account.")
+    first: ConflictEventRef = Field(..., description="The event that starts earlier.")
+    second: ConflictEventRef = Field(..., description="The event that starts later.")
+
+
+class TightTransition(BaseModel):
+    """Two events that do not overlap but leave less than the preferred buffer."""
+    gap_minutes: float = Field(..., description="Minutes between the first ending and the second starting.")
+    buffer_minutes: int = Field(..., description="Gap the user's preferences ask for.")
+    first: ConflictEventRef = Field(..., description="The event that ends first.")
+    second: ConflictEventRef = Field(..., description="The event that starts next.")
+
+
+class ConflictsResult(BaseModel):
+    """Result of the detect_conflicts tool."""
+    time_min: str = Field(..., description="Start of the checked window, ISO 8601.")
+    time_max: str = Field(..., description="End of the checked window, ISO 8601.")
+    timezone: str = Field(..., description="Timezone the times are expressed in.")
+    accounts: List[str] = Field(default_factory=list, description="Accounts that were read.")
+    calendar_ids: List[str] = Field(
+        default_factory=list, description="Calendars that were read, as 'account:calendar_id'."
+    )
+    event_count: int = Field(0, description="Events considered after filtering.")
+    buffer_minutes: int = Field(0, description="Buffer the tight transitions were judged against.")
+    include_all_day: bool = Field(False, description="Whether all-day events were considered.")
+    conflict_count: int = Field(0, description="Number of overlapping pairs.")
+    conflicts: List[EventConflict] = Field(
+        default_factory=list, description="Overlapping pairs, earliest first."
+    )
+    tight_count: int = Field(0, description="Number of too-tight transitions.")
+    tight: List[TightTransition] = Field(
+        default_factory=list, description="Back-to-back pairs that violate the buffer, earliest first."
+    )
+    skipped: List[str] = Field(
+        default_factory=list,
+        description="Calendars or accounts that could not be read in full, with the reason.",
+    )
+    message: str = Field("", description="One-line human-readable summary.")
+
+
+class RescheduleSuggestion(BaseModel):
+    """One proposed new time for an event, with why it scored as it did."""
+    start: str = Field(..., description="Proposed start, ISO 8601.")
+    end: str = Field(..., description="Proposed end, ISO 8601.")
+    score: float = Field(..., description="Higher is better; 100 is a clean slot with no penalties.")
+    attendee_conflicts: List[str] = Field(
+        default_factory=list, description="Attendees who are busy then. Empty means everyone is free."
+    )
+    reasons: List[str] = Field(
+        default_factory=list, description="Short phrases explaining the score."
+    )
+
+
+class RescheduleSuggestions(BaseModel):
+    """Result of the suggest_reschedule tool. Read-only unless 'apply' was set."""
+    calendar_id: str = Field(..., description="Calendar the event lives on.")
+    event_id: str = Field(..., description="Event the suggestions are for.")
+    summary: Optional[str] = Field(None, description="Event title.")
+    current_start: Optional[str] = Field(None, description="Where the event sits now, ISO 8601.")
+    current_end: Optional[str] = Field(None, description="Current end, ISO 8601.")
+    duration_minutes: float = Field(0.0, description="Length of the event, preserved by every suggestion.")
+    timezone: str = Field(..., description="Timezone the suggestions are expressed in.")
+    attendees: List[str] = Field(
+        default_factory=list, description="Attendee calendars whose availability was checked."
+    )
+    search_time_min: str = Field(..., description="Start of the searched window, ISO 8601.")
+    search_time_max: str = Field(..., description="End of the searched window, ISO 8601.")
+    count: int = Field(0, description="Number of suggestions returned.")
+    suggestions: List[RescheduleSuggestion] = Field(
+        default_factory=list, description="Proposed times, best first."
+    )
+    applied: bool = Field(False, description="True when the event was actually moved.")
+    applied_event: Optional[EventInfo] = Field(
+        None, description="The event after the move; null unless 'applied' is true."
+    )
+    message: str = Field("", description="One-line human-readable summary.")

--- a/calendar_mcp/preferences.py
+++ b/calendar_mcp/preferences.py
@@ -1,0 +1,367 @@
+"""User scheduling preferences: working hours, buffers, lunch, focus time.
+
+One JSON file, ``<config dir>/preferences.json`` (see
+:func:`calendar_mcp.accounts.config_dir`), holds the answers to the questions
+every scheduling tool otherwise has to ask again: when does this person work,
+how much air do they want around a meeting, when do they eat, how long does a
+block have to be before it counts as focus time.
+
+Preferences are global rather than per-account on purpose: they describe the
+human, not the mailbox.
+
+Reading is cheap and always succeeds -- a missing or corrupt file yields
+:class:`Preferences` defaults (Mon-Fri 09:00-17:00) rather than an error, so no
+tool has to special-case a first run.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import threading
+from datetime import datetime, time as dt_time
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from pydantic import BaseModel, Field, field_validator
+
+from . import accounts as accounts_module
+from .timeutil import Interval, combine, format_clock, iter_days, parse_clock, subtract_intervals
+
+logger = logging.getLogger(__name__)
+
+PREFERENCES_FILE = "preferences.json"
+
+#: A wall-clock ``('HH:MM', 'HH:MM')`` span, interpreted in the user's timezone.
+TimeRange = Tuple[str, str]
+
+#: Weekday keys, indexed by :meth:`datetime.date.weekday` (0 = Monday).
+WEEKDAYS: Tuple[str, ...] = ("mon", "tue", "wed", "thu", "fri", "sat", "sun")
+
+_ALIASES = {
+    "monday": "mon", "tuesday": "tue", "wednesday": "wed", "thursday": "thu",
+    "friday": "fri", "saturday": "sat", "sunday": "sun",
+    "m": "mon", "tu": "tue", "w": "wed", "th": "thu", "f": "fri",
+    "sa": "sat", "su": "sun",
+}
+
+_write_lock = threading.Lock()
+
+
+def default_working_hours() -> Dict[str, List[TimeRange]]:
+    """The out-of-the-box schedule: Mon-Fri 09:00-17:00, weekends off."""
+    return {
+        "mon": [("09:00", "17:00")],
+        "tue": [("09:00", "17:00")],
+        "wed": [("09:00", "17:00")],
+        "thu": [("09:00", "17:00")],
+        "fri": [("09:00", "17:00")],
+        "sat": [],
+        "sun": [],
+    }
+
+
+def normalise_weekday(key: str) -> str:
+    """Maps ``'Monday'``/``'MON'``/``'m'`` onto the canonical ``'mon'``.
+
+    Raises:
+        ValueError: If the key names no weekday.
+    """
+    text = str(key).strip().lower()
+    if text in WEEKDAYS:
+        return text
+    if text in _ALIASES:
+        return _ALIASES[text]
+    raise ValueError(
+        f"Unknown weekday {key!r}. Use one of: {', '.join(WEEKDAYS)}."
+    )
+
+
+def _clean_ranges(value, weekday: str) -> List[TimeRange]:
+    """Validates one day's list of ``('HH:MM', 'HH:MM')`` spans."""
+    if value is None:
+        return []
+    if isinstance(value, (str, bytes)):
+        raise ValueError(
+            f"working_hours['{weekday}'] must be a list of ['HH:MM', 'HH:MM'] pairs."
+        )
+    cleaned: List[TimeRange] = []
+    for item in value:
+        if isinstance(item, (str, bytes)) or len(tuple(item)) != 2:
+            raise ValueError(
+                f"working_hours['{weekday}'] entries must be ['HH:MM', 'HH:MM'] pairs; "
+                f"got {item!r}."
+            )
+        raw_start, raw_end = tuple(item)
+        start = parse_clock(str(raw_start), f"working_hours['{weekday}'] start")
+        end = parse_clock(str(raw_end), f"working_hours['{weekday}'] end")
+        if start is None or end is None:
+            raise ValueError(f"working_hours['{weekday}'] entries need both a start and an end.")
+        if end <= start:
+            raise ValueError(
+                f"working_hours['{weekday}'] end must be after start; got "
+                f"{format_clock(start)}-{format_clock(end)}."
+            )
+        cleaned.append((format_clock(start), format_clock(end)))
+    cleaned.sort()
+    return cleaned
+
+
+class Preferences(BaseModel):
+    """How this user wants their time scheduled."""
+
+    timezone: Optional[str] = Field(
+        None,
+        description="IANA timezone the working hours are expressed in, e.g. 'Europe/Berlin'. "
+        "Omit to use the calendar's own timezone.",
+    )
+    working_hours: Dict[str, List[TimeRange]] = Field(
+        default_factory=default_working_hours,
+        description="Per-weekday working spans, keyed 'mon'..'sun', each a list of "
+        "['HH:MM', 'HH:MM'] pairs. An empty list means the day is off.",
+    )
+    buffer_minutes: int = Field(
+        0,
+        ge=0,
+        le=240,
+        description="Minimum gap to leave before and after each meeting when scheduling.",
+    )
+    min_focus_block_minutes: int = Field(
+        60,
+        ge=0,
+        le=1440,
+        description="Shortest free stretch that still counts as usable focus time.",
+    )
+    lunch: Optional[TimeRange] = Field(
+        None,
+        description="Daily lunch break as ['HH:MM', 'HH:MM'], carved out of the working hours. "
+        "Omit for no lunch break.",
+    )
+    focus_calendar_id: str = Field(
+        "primary",
+        description="Calendar that focus blocks are booked on.",
+    )
+
+    @field_validator("timezone")
+    @classmethod
+    def _check_timezone(cls, value: Optional[str]) -> Optional[str]:
+        if value is None or not str(value).strip():
+            return None
+        name = str(value).strip()
+        try:
+            ZoneInfo(name)
+        except (ZoneInfoNotFoundError, ValueError, KeyError) as exc:
+            raise ValueError(
+                f"timezone {name!r} is not a known IANA zone (e.g. 'America/New_York')."
+            ) from exc
+        return name
+
+    @field_validator("working_hours", mode="before")
+    @classmethod
+    def _check_working_hours(cls, value):
+        if value is None:
+            return default_working_hours()
+        if not isinstance(value, dict):
+            raise ValueError("working_hours must be an object keyed by weekday ('mon'..'sun').")
+        cleaned: Dict[str, List[TimeRange]] = {day: [] for day in WEEKDAYS}
+        for key, spans in value.items():
+            day = normalise_weekday(key)
+            cleaned[day] = _clean_ranges(spans, day)
+        return cleaned
+
+    @field_validator("lunch", mode="before")
+    @classmethod
+    def _check_lunch(cls, value):
+        if value is None:
+            return None
+        if isinstance(value, (str, bytes)) or len(tuple(value)) != 2:
+            raise ValueError("lunch must be a ['HH:MM', 'HH:MM'] pair, or omitted.")
+        raw_start, raw_end = tuple(value)
+        start = parse_clock(str(raw_start), "lunch start")
+        end = parse_clock(str(raw_end), "lunch end")
+        if start is None or end is None:
+            raise ValueError("lunch needs both a start and an end.")
+        if end <= start:
+            raise ValueError("lunch end must be after lunch start.")
+        return (format_clock(start), format_clock(end))
+
+    @field_validator("focus_calendar_id")
+    @classmethod
+    def _check_focus_calendar(cls, value: str) -> str:
+        text = (value or "").strip()
+        if not text:
+            raise ValueError("focus_calendar_id cannot be empty; use 'primary' for the main calendar.")
+        return text
+
+    # -- convenience -------------------------------------------------------
+
+    def tzinfo(self, fallback=None):
+        """The configured timezone as a tzinfo, or ``fallback`` when unset."""
+        if self.timezone:
+            try:
+                return ZoneInfo(self.timezone)
+            except (ZoneInfoNotFoundError, ValueError):  # pragma: no cover - validated on write
+                logger.warning("Preferred timezone %r is not resolvable.", self.timezone)
+        return fallback
+
+    def spans_for(self, weekday_index: int) -> List[TimeRange]:
+        """The working spans for a ``date.weekday()`` index (0 = Monday)."""
+        return list(self.working_hours.get(WEEKDAYS[weekday_index % 7], []))
+
+
+# ---------------------------------------------------------------------------
+# Storage
+# ---------------------------------------------------------------------------
+
+
+def preferences_path() -> str:
+    """Absolute path of ``preferences.json``."""
+    return str(accounts_module.config_dir() / PREFERENCES_FILE)
+
+
+def load() -> Preferences:
+    """Reads the saved preferences, falling back to defaults.
+
+    A missing file is normal. An unreadable or invalid one is logged and
+    ignored rather than raised, so a bad edit cannot wedge every tool.
+    """
+    path = preferences_path()
+    if not os.path.exists(path):
+        return Preferences()
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except (OSError, ValueError) as exc:
+        logger.warning("Could not read %s (%s); using default preferences.", path, exc)
+        return Preferences()
+    try:
+        return Preferences.model_validate(data)
+    except Exception as exc:
+        logger.warning("%s is not valid (%s); using default preferences.", path, exc)
+        return Preferences()
+
+
+def save(prefs: Preferences) -> str:
+    """Writes ``prefs`` to ``preferences.json`` and returns the path.
+
+    The write is atomic: a temp file in the same directory is replaced into
+    position, so a crash mid-write cannot leave a half-written file behind.
+    """
+    directory = accounts_module.ensure_config_dir()
+    target = directory / PREFERENCES_FILE
+    payload = json.dumps(prefs.model_dump(mode="json"), indent=2, sort_keys=True)
+    with _write_lock:
+        handle = tempfile.NamedTemporaryFile(
+            "w", encoding="utf-8", dir=str(directory), prefix=".preferences-", suffix=".tmp",
+            delete=False,
+        )
+        try:
+            with handle:
+                handle.write(payload + "\n")
+            os.replace(handle.name, target)
+        except BaseException:
+            try:
+                os.unlink(handle.name)
+            except OSError:  # pragma: no cover - best effort
+                pass
+            raise
+    logger.info("Saved preferences to %s", target)
+    return str(target)
+
+
+def merge(current: Preferences, **updates) -> Preferences:
+    """Returns a copy of ``current`` with the non-``None`` ``updates`` applied.
+
+    Validation runs on the merged whole, so a rejected update leaves the saved
+    preferences untouched.
+
+    Raises:
+        ValueError: If the merged result is not valid (pydantic's message says
+            which field).
+    """
+    data = current.model_dump(mode="json")
+    for key, value in updates.items():
+        if value is None:
+            continue
+        data[key] = value
+    return Preferences.model_validate(data)
+
+
+# ---------------------------------------------------------------------------
+# Working windows
+# ---------------------------------------------------------------------------
+
+
+def working_windows(
+    prefs: Preferences,
+    time_min: datetime,
+    time_max: datetime,
+    tzinfo=None,
+) -> List[Interval]:
+    """The user's working time inside ``[time_min, time_max)``, lunch removed.
+
+    Each day in the range contributes its configured spans, expressed in
+    ``tzinfo`` (or ``prefs.timezone``, or the timezone of ``time_min``), minus
+    the lunch break. The result is clipped to the requested window, so a caller
+    can hand it straight to :func:`calendar_mcp.timeutil.free_windows`.
+
+    Args:
+        prefs: The preferences to read working hours and lunch from.
+        time_min: Inclusive start of the range, aware.
+        time_max: Exclusive end of the range, aware.
+        tzinfo: Zone the wall-clock hours are read in. Defaults to
+            ``prefs.timezone`` when set, else ``time_min``'s own zone.
+
+    Returns:
+        Aware ``(start, end)`` pairs, earliest first. Empty when the range holds
+        no working time.
+    """
+    zone = tzinfo or prefs.tzinfo(time_min.tzinfo)
+    if zone is None:  # pragma: no cover - callers pass aware datetimes
+        raise ValueError("working_windows needs a timezone: pass tzinfo or set prefs.timezone.")
+
+    lunch_clocks: Optional[Tuple[dt_time, dt_time]] = None
+    if prefs.lunch:
+        lunch_start = parse_clock(prefs.lunch[0], "lunch start")
+        lunch_end = parse_clock(prefs.lunch[1], "lunch end")
+        if lunch_start and lunch_end:
+            lunch_clocks = (lunch_start, lunch_end)
+
+    windows: List[Interval] = []
+    for day in iter_days(time_min, time_max, zone):
+        for raw_start, raw_end in prefs.spans_for(day.weekday()):
+            start_clock = parse_clock(raw_start, "working hours start")
+            end_clock = parse_clock(raw_end, "working hours end")
+            if start_clock is None or end_clock is None:  # pragma: no cover - validated
+                continue
+            span = (combine(day, start_clock, zone), combine(day, end_clock, zone))
+            pieces = [span]
+            if lunch_clocks is not None:
+                cut = (combine(day, lunch_clocks[0], zone), combine(day, lunch_clocks[1], zone))
+                pieces = subtract_intervals(span, [cut])
+            for piece_start, piece_end in pieces:
+                clipped_start = max(piece_start, time_min)
+                clipped_end = min(piece_end, time_max)
+                if clipped_end > clipped_start:
+                    windows.append((clipped_start, clipped_end))
+
+    windows.sort(key=lambda pair: pair[0])
+    return windows
+
+
+__all__ = [
+    "PREFERENCES_FILE",
+    "Preferences",
+    "TimeRange",
+    "WEEKDAYS",
+    "default_working_hours",
+    "load",
+    "merge",
+    "normalise_weekday",
+    "preferences_path",
+    "save",
+    "working_windows",
+]

--- a/calendar_mcp/scheduling.py
+++ b/calendar_mcp/scheduling.py
@@ -1,0 +1,407 @@
+"""Pure scheduling logic: focus blocks, conflict detection and slot ranking.
+
+Everything here is a function of its arguments: no credentials, no Google
+client, no disk, no clock. The tools in :mod:`calendar_mcp.tools.focus` and
+:mod:`calendar_mcp.tools.conflicts` fetch the raw material (working windows from
+:mod:`calendar_mcp.preferences`, busy intervals from Google) and hand it to
+these helpers, which is what makes the interesting behaviour unit-testable
+without a network.
+
+The vocabulary is the one :mod:`calendar_mcp.timeutil` established: an
+*interval* is an aware ``(start, end)`` pair with ``start <= end``. Events are
+addressed by *index* into the caller's own list -- these functions never see an
+event, only its span -- so the caller keeps ownership of titles, IDs and
+calendars.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+from .timeutil import Interval, free_windows, merge_intervals
+
+__all__ = [
+    "ScoredSlot",
+    "BASE_SCORE",
+    "CONFLICT_PENALTY",
+    "SAME_DAY_BONUS",
+    "BUFFER_PENALTY",
+    "interval_minutes",
+    "total_minutes",
+    "total_hours",
+    "overlap_minutes",
+    "candidate_blocks",
+    "rank_blocks",
+    "select_blocks",
+    "overlapping_pairs",
+    "tight_pairs",
+    "align_up",
+    "generate_slots",
+    "conflicting_keys",
+    "violates_buffer",
+    "rank_slots",
+]
+
+
+# ---------------------------------------------------------------------------
+# Measuring
+# ---------------------------------------------------------------------------
+
+
+def interval_minutes(interval: Interval) -> float:
+    """Length of one interval in minutes (0.0 when inverted)."""
+    start, end = interval
+    return max(0.0, (end - start).total_seconds() / 60.0)
+
+
+def total_minutes(intervals: Iterable[Interval]) -> float:
+    """Summed length of ``intervals`` in minutes. Overlaps are merged away first."""
+    return sum(interval_minutes(item) for item in merge_intervals(intervals))
+
+
+def total_hours(intervals: Iterable[Interval]) -> float:
+    """Summed length of ``intervals`` in hours, rounded to two decimals."""
+    return round(total_minutes(intervals) / 60.0, 2)
+
+
+def overlap_minutes(first: Interval, second: Interval) -> float:
+    """Minutes the two intervals share. 0.0 when they merely touch."""
+    start = max(first[0], second[0])
+    end = min(first[1], second[1])
+    return max(0.0, (end - start).total_seconds() / 60.0)
+
+
+# ---------------------------------------------------------------------------
+# Focus blocks
+# ---------------------------------------------------------------------------
+
+
+def candidate_blocks(
+    windows: Sequence[Interval],
+    busy: Sequence[Interval],
+    min_block_minutes: int = 0,
+    buffer_minutes: int = 0,
+) -> List[Interval]:
+    """The usable free stretches inside ``windows``.
+
+    Each working window has the busy intervals cut out of it -- grown by
+    ``buffer_minutes`` on both sides first, so a block never starts the instant
+    a meeting ends -- and whatever survives is kept when it is at least
+    ``min_block_minutes`` long.
+
+    Args:
+        windows: Working windows to search inside, e.g. from
+            :func:`calendar_mcp.preferences.working_windows`.
+        busy: Busy intervals across every calendar that matters, in any order.
+        min_block_minutes: Shortest stretch that still counts as focus time.
+        buffer_minutes: Breathing room to leave around each busy interval.
+
+    Returns:
+        Disjoint ``(start, end)`` pairs in chronological order.
+    """
+    blocks: List[Interval] = []
+    for window in windows:
+        if window[1] <= window[0]:
+            continue
+        for piece in free_windows(busy, window, buffer_minutes):
+            if interval_minutes(piece) + 1e-9 >= float(min_block_minutes):
+                blocks.append(piece)
+    blocks.sort(key=lambda pair: pair[0])
+    return blocks
+
+
+def rank_blocks(blocks: Iterable[Interval]) -> List[Interval]:
+    """Orders blocks the way a person picks focus time: longest first, then earliest."""
+    return sorted(blocks, key=lambda pair: (-interval_minutes(pair), pair[0]))
+
+
+def select_blocks(
+    blocks: Sequence[Interval],
+    hours_needed: float,
+    min_block_minutes: int = 0,
+) -> List[Interval]:
+    """Takes blocks, longest first, until ``hours_needed`` is covered.
+
+    The last block taken is trimmed to what is still needed, rather than booking
+    a whole afternoon for a final twenty minutes -- but never trimmed below
+    ``min_block_minutes``, so every block handed back is still a usable one.
+
+    Args:
+        blocks: Candidate blocks, e.g. from :func:`candidate_blocks`.
+        hours_needed: How much focus time to gather. ``0`` selects nothing.
+        min_block_minutes: Floor for the trimmed final block.
+
+    Returns:
+        The chosen blocks in chronological order. Adds up to less than
+        ``hours_needed`` when the candidates simply do not stretch that far.
+    """
+    remaining = max(0.0, float(hours_needed)) * 60.0
+    chosen: List[Interval] = []
+    for start, end in rank_blocks(blocks):
+        if remaining <= 1e-9:
+            break
+        available = interval_minutes((start, end))
+        take = min(available, max(remaining, float(min_block_minutes)))
+        chosen.append((start, start + timedelta(minutes=take)))
+        remaining -= take
+    chosen.sort(key=lambda pair: pair[0])
+    return chosen
+
+
+# ---------------------------------------------------------------------------
+# Conflicts
+# ---------------------------------------------------------------------------
+
+
+def overlapping_pairs(intervals: Sequence[Interval]) -> List[Tuple[int, int, float]]:
+    """Finds every pair of intervals that genuinely overlap.
+
+    Args:
+        intervals: Event spans, in any order. Indices into this sequence are
+            what the result refers to.
+
+    Returns:
+        ``(earlier_index, later_index, overlap_minutes)`` triples, ordered by
+        the earlier event's start. Touching intervals -- one ending exactly when
+        the next begins -- are not overlaps.
+    """
+    order = sorted(range(len(intervals)), key=lambda i: (intervals[i][0], intervals[i][1]))
+    pairs: List[Tuple[int, int, float]] = []
+    for position, index in enumerate(order):
+        start, end = intervals[index]
+        for other in order[position + 1:]:
+            # Starts are non-decreasing, so once one begins at or after this
+            # event ends, every later one does too.
+            if intervals[other][0] >= end:
+                break
+            shared = overlap_minutes((start, end), intervals[other])
+            if shared > 0:
+                pairs.append((index, other, shared))
+    return pairs
+
+
+def tight_pairs(
+    intervals: Sequence[Interval],
+    buffer_minutes: int,
+) -> List[Tuple[int, int, float]]:
+    """Finds back-to-back pairs that leave less than ``buffer_minutes`` between them.
+
+    These are not conflicts -- nothing is double-booked -- but they are the
+    transitions that make a day feel impossible, so they are worth reporting
+    separately.
+
+    Returns:
+        ``(earlier_index, later_index, gap_minutes)`` triples, ordered by the
+        earlier event's start. Empty when ``buffer_minutes`` is zero or less.
+    """
+    if not buffer_minutes or buffer_minutes <= 0:
+        return []
+    order = sorted(range(len(intervals)), key=lambda i: (intervals[i][0], intervals[i][1]))
+    pairs: List[Tuple[int, int, float]] = []
+    for position, index in enumerate(order):
+        end = intervals[index][1]
+        for other in order[position + 1:]:
+            gap = (intervals[other][0] - end).total_seconds() / 60.0
+            if gap < 0:
+                continue  # overlapping: a conflict, not a tight transition
+            if gap >= buffer_minutes:
+                break  # starts only get later, so every later gap is bigger
+            pairs.append((index, other, gap))
+    return pairs
+
+
+# ---------------------------------------------------------------------------
+# Slot generation and ranking
+# ---------------------------------------------------------------------------
+
+
+def align_up(moment: datetime, step_minutes: int) -> datetime:
+    """Rounds ``moment`` up to the next ``step_minutes`` mark past the hour.
+
+    Keeps proposed times on the boundaries people expect -- :00, :15, :30, :45
+    for a 15-minute step -- instead of at 09:07 because that is when a meeting
+    happened to end.
+    """
+    if step_minutes <= 0:
+        return moment
+    trimmed = moment.replace(second=0, microsecond=0)
+    if trimmed < moment:
+        trimmed += timedelta(minutes=1)
+    remainder = trimmed.minute % step_minutes
+    if remainder:
+        trimmed += timedelta(minutes=step_minutes - remainder)
+    return trimmed
+
+
+def generate_slots(
+    windows: Sequence[Interval],
+    duration_minutes: int,
+    step_minutes: int = 15,
+    limit: Optional[int] = None,
+) -> List[Interval]:
+    """Every ``duration_minutes`` slot that fits inside ``windows``, on a grid.
+
+    Args:
+        windows: Windows the slot has to sit inside (typically working hours).
+        duration_minutes: Length of the slot to place.
+        step_minutes: Spacing of the candidate start times.
+        limit: Stop after this many candidates. ``None`` for all of them.
+
+    Returns:
+        Candidate ``(start, end)`` pairs in chronological order.
+    """
+    if duration_minutes <= 0:
+        return []
+    length = timedelta(minutes=duration_minutes)
+    step = timedelta(minutes=max(1, step_minutes))
+    slots: List[Interval] = []
+    for window_start, window_end in sorted(windows, key=lambda pair: pair[0]):
+        cursor = align_up(window_start, step_minutes)
+        while cursor + length <= window_end:
+            slots.append((cursor, cursor + length))
+            if limit is not None and len(slots) >= limit:
+                return slots
+            cursor += step
+    return slots
+
+
+def conflicting_keys(
+    slot: Interval,
+    busy_by_key: Mapping[str, Sequence[Interval]],
+) -> List[str]:
+    """The keys of ``busy_by_key`` whose intervals overlap ``slot``, sorted."""
+    clashing = [
+        key
+        for key, intervals in busy_by_key.items()
+        if any(overlap_minutes(slot, interval) > 0 for interval in intervals)
+    ]
+    return sorted(clashing)
+
+
+def violates_buffer(
+    slot: Interval,
+    busy: Iterable[Interval],
+    buffer_minutes: int,
+) -> bool:
+    """True when ``slot`` sits closer than ``buffer_minutes`` to a busy interval.
+
+    Overlaps do not count here: an overlap is a conflict, which the caller
+    reports separately and weighs far more heavily.
+    """
+    if not buffer_minutes or buffer_minutes <= 0:
+        return False
+    start, end = slot
+    for busy_start, busy_end in busy:
+        if overlap_minutes(slot, (busy_start, busy_end)) > 0:
+            continue
+        if busy_end <= start:
+            gap = (start - busy_end).total_seconds() / 60.0
+        elif busy_start >= end:
+            gap = (busy_start - end).total_seconds() / 60.0
+        else:  # pragma: no cover - an overlap, already skipped above
+            continue
+        if gap < buffer_minutes:
+            return True
+    return False
+
+
+@dataclass(frozen=True)
+class ScoredSlot:
+    """One ranked candidate time, with the reasoning that produced its score."""
+
+    start: datetime
+    end: datetime
+    score: float
+    conflicts: Tuple[str, ...] = ()
+    reasons: Tuple[str, ...] = ()
+
+
+#: Score every candidate starts from, before penalties and bonuses.
+BASE_SCORE = 100.0
+#: Cost of one attendee being busy during the slot.
+CONFLICT_PENALTY = 25.0
+#: Reward for landing on the day the meeting is already on.
+SAME_DAY_BONUS = 10.0
+#: Cost of sitting closer to another meeting than the user's buffer allows.
+BUFFER_PENALTY = 8.0
+
+
+def rank_slots(
+    candidates: Sequence[Interval],
+    busy_by_key: Optional[Mapping[str, Sequence[Interval]]] = None,
+    unavailable: Sequence[Interval] = (),
+    original_start: Optional[datetime] = None,
+    buffer_minutes: int = 0,
+    tzinfo=None,
+    limit: Optional[int] = None,
+) -> List[ScoredSlot]:
+    """Scores candidate slots and returns the best ones, best first.
+
+    Ranking, in the order a person would argue it: fewest attendee conflicts
+    first, then the day the meeting is already on, then earliest. A slot that
+    leaves less than the user's buffer against an adjacent meeting is still
+    offered, but penalised.
+
+    Args:
+        candidates: Slots to consider, e.g. from :func:`generate_slots`.
+        busy_by_key: Busy intervals per attendee. The key is whatever the caller
+            wants to read back in ``conflicts`` -- usually an email address.
+        unavailable: Hard blocks: a slot overlapping one of these is dropped
+            entirely. Use it for the organiser's own calendar.
+        original_start: Where the meeting currently sits, for the same-day bonus.
+        buffer_minutes: The user's preferred gap around meetings.
+        tzinfo: Zone the "same day" comparison is made in. Defaults to
+            ``original_start``'s own zone.
+        limit: Keep only this many results.
+
+    Returns:
+        :class:`ScoredSlot` values, highest score first and earliest within a
+        score.
+    """
+    busy_map: Dict[str, Sequence[Interval]] = dict(busy_by_key or {})
+    blocked = list(unavailable)
+    zone = tzinfo or (original_start.tzinfo if original_start else None)
+    original_day = original_start.astimezone(zone).date() if original_start and zone else None
+
+    neighbours: List[Interval] = list(blocked)
+    for intervals in busy_map.values():
+        neighbours.extend(intervals)
+
+    scored: List[ScoredSlot] = []
+    for slot in candidates:
+        if any(overlap_minutes(slot, block) > 0 for block in blocked):
+            continue
+        conflicts = conflicting_keys(slot, busy_map)
+        score = BASE_SCORE - CONFLICT_PENALTY * len(conflicts)
+        reasons: List[str] = []
+
+        if busy_map and not conflicts:
+            reasons.append(f"all {len(busy_map)} attendee(s) free")
+        elif len(conflicts) == 1:
+            reasons.append(f"busy: {conflicts[0]}")
+        elif conflicts:
+            reasons.append(f"{len(conflicts)} attendees busy")
+
+        if original_day is not None and zone is not None:
+            if slot[0].astimezone(zone).date() == original_day:
+                score += SAME_DAY_BONUS
+                reasons.append("same day as the original")
+
+        if violates_buffer(slot, neighbours, buffer_minutes):
+            score -= BUFFER_PENALTY
+            reasons.append(f"less than {buffer_minutes} min from another meeting")
+
+        scored.append(
+            ScoredSlot(
+                start=slot[0],
+                end=slot[1],
+                score=round(score, 2),
+                conflicts=tuple(conflicts),
+                reasons=tuple(reasons),
+            )
+        )
+
+    scored.sort(key=lambda item: (-item.score, item.start))
+    return scored[:limit] if limit is not None else scored

--- a/calendar_mcp/server.py
+++ b/calendar_mcp/server.py
@@ -6,6 +6,46 @@ directly, and returns a pydantic model so the MCP client gets structured output.
 Google credentials are loaded lazily, on the first tool call that needs them, so
 the MCP handshake answers instantly and a missing token surfaces as a readable
 tool error rather than a hung startup.
+
+**This module holds the plumbing, not the tools.** The tools themselves live in
+:mod:`calendar_mcp.tools`, one module per subject area, and register themselves
+against the ``server`` instance created here when that package is imported (the
+last line of this file). To add a tool, write it in a ``calendar_mcp/tools/``
+module -- there is no need to touch this file:
+
+.. code-block:: python
+
+    # calendar_mcp/tools/my_area.py
+    from typing import Optional
+
+    from calendar_mcp import server as srv
+    from calendar_mcp.models import EventListResult
+
+
+    @srv.server.tool(name="my_tool", title="My tool", annotations=srv.READ_ONLY)
+    async def my_tool(
+        calendar_id: str = "primary",
+        account: Optional[str] = None,
+        ctx: Optional[srv.Context] = None,
+    ) -> EventListResult:
+        \"\"\"One-line summary the model sees.
+
+        Args:
+            calendar_id: Calendar to read.
+            account: Account name from 'calendar-mcp accounts'; omit for the default.
+        \"\"\"
+        provider = srv._provider(ctx)
+
+        def work() -> EventListResult:
+            creds = provider.get(account)
+            ...
+
+        return await srv._run(work)
+
+...then add the module to the import list in ``calendar_mcp/tools/__init__.py``.
+Reach Google through ``srv.calendar_actions`` rather than importing
+``calendar_actions`` directly: the test suite patches that attribute on this
+module, and going through ``srv`` keeps every tool mockable from one place.
 """
 
 from __future__ import annotations
@@ -16,8 +56,8 @@ import logging
 import threading
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from datetime import datetime, time as dt_time, timedelta, timezone
-from typing import Any, AsyncIterator, Callable, List, Optional, TypeVar
+from datetime import datetime, time as dt_time, timezone
+from typing import Any, AsyncIterator, Callable, Dict, Optional, TypeVar
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import anyio
@@ -29,27 +69,18 @@ from mcp.server.mcpserver.exceptions import ToolError
 from mcp.types import ToolAnnotations
 from pydantic import BaseModel, Field
 
-from . import auth, calendar_actions
+from . import accounts, auth, calendar_actions, preferences
 from .auth import AuthError
-from .models import (
-    AttendeeStatusEntry,
-    AttendeeStatusResult,
-    BusyPeriod,
-    BusynessResult,
-    CalendarBusyPeriods,
-    CalendarInfo,
-    CalendarListResult,
-    DayBusyness,
-    DeleteEventResult,
-    EventCreateRequest,
-    EventDateTime,
-    EventInfo,
-    EventListResult,
-    EventResult,
-    EventUpdateRequest,
-    FreeBusyResult,
-    ProjectedEventsResult,
-    ProjectedOccurrence,
+from .timeutil import (
+    Interval,
+    clip_intervals,
+    combine,
+    format_clock,
+    free_windows,
+    iter_days,
+    merge_intervals,
+    parse_clock,
+    subtract_intervals,
 )
 
 logger = logging.getLogger(__name__)
@@ -57,7 +88,11 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 SERVER_NAME = "calendar-mcp"
-SERVER_VERSION = "1.0.1"
+SERVER_VERSION = "1.1.0"
+
+#: Shared wording for the ``account`` argument every tool accepts, so the
+#: description a client sees is identical everywhere.
+ACCOUNT_ARG_DOC = "Account name from 'calendar-mcp accounts'; omit for the default."
 
 INSTRUCTIONS = """\
 Read and manage the user's Google Calendar.
@@ -84,6 +119,14 @@ Workflow notes:
   * `delete_event` is irreversible and may ask the user to confirm.
   * `query_free_busy` and `schedule_mutual` read other people's calendars by
     email address; they return busy intervals only, never event details.
+
+Several Google accounts can be signed in at once. Every tool takes an optional
+`account` name; omit it for the user's default. `list_accounts` shows which
+accounts exist and whether each one is still authorized.
+
+`get_preferences` reports the user's working hours, lunch break, meeting buffer
+and focus-block settings. Read them before proposing times, rather than assuming
+a 9-to-5; `set_preferences` records a correction the user gives you.
 """
 
 
@@ -130,53 +173,112 @@ def _http_error_message(error: HttpError) -> str:
 
 
 class CredentialProvider:
-    """Lazily loads, caches and refreshes Google credentials.
+    """Lazily loads, caches and refreshes Google credentials, per account.
 
     Nothing touches the network until :meth:`get` is first called, which happens
-    on the first tool invocation rather than at server startup.
+    on the first tool invocation rather than at server startup. Credentials are
+    cached per resolved account name, so a session that talks to both ``work``
+    and ``personal`` reads each token once.
     """
 
     def __init__(self) -> None:
-        self._creds: Optional[Credentials] = None
+        self._creds: Dict[str, Credentials] = {}
         self._lock = threading.Lock()
 
-    def get(self) -> Credentials:
-        """Returns valid credentials, refreshing or reloading as needed.
+    def get(self, account: Optional[str] = None) -> Credentials:
+        """Returns valid credentials for ``account``, reloading as needed.
+
+        Args:
+            account: Account name, or ``None`` for the resolved default.
 
         Raises:
             AuthError: When no usable token exists (the message says what to do).
         """
+        name = accounts.resolve_account(account)
         with self._lock:
-            if self._creds is not None and self._creds.valid:
-                return self._creds
-            # auth.get_credentials refreshes an expired token itself and will not
-            # open a browser unless CALENDAR_MCP_ALLOW_BROWSER_AUTH is set.
-            self._creds = auth.get_credentials()
-            return self._creds
+            cached = self._creds.get(name)
+            if cached is not None and cached.valid:
+                return cached
+            token_path = accounts.token_path_for(name)
+            try:
+                # auth.get_credentials refreshes an expired token itself and will
+                # not open a browser unless CALENDAR_MCP_ALLOW_BROWSER_AUTH is set.
+                creds = auth.get_credentials(path=token_path)
+            except AuthError as exc:
+                raise AuthError(self._auth_hint(name, exc)) from exc
+            # Tag the credentials with the account they belong to, so
+            # account-agnostic helpers (the calendar-timezone cache) can tell
+            # one account's 'primary' from another's without every tool having
+            # to thread the account name through.
+            try:
+                creds._calendar_mcp_account = name
+            except AttributeError:  # pragma: no cover - exotic Credentials subclass
+                pass
+            self._creds[name] = creds
+            return creds
 
-    def reset(self) -> None:
-        """Drops the cached credentials so the next call reloads from disk."""
+    @staticmethod
+    def _auth_hint(name: str, exc: AuthError) -> str:
+        """Adds the account name to an auth failure when it is not the default."""
+        if name == accounts.DEFAULT_ACCOUNT:
+            return str(exc)
+        return (
+            f"{exc} (account '{name}'; run 'calendar-mcp auth --account {name}'. "
+            f"Known accounts: {accounts.describe_known_accounts()}.)"
+        )
+
+    def reset(self, account: Optional[str] = None) -> None:
+        """Drops cached credentials so the next call reloads from disk.
+
+        Args:
+            account: Only forget this account. ``None`` forgets all of them.
+        """
         with self._lock:
-            self._creds = None
+            if account is None:
+                self._creds.clear()
+            else:
+                self._creds.pop(accounts.resolve_account(account), None)
 
 
 credential_provider = CredentialProvider()
 
 # Calendar timezones are stable; cache them so naive timestamps do not cost an
-# extra API round trip on every call.
-_timezone_cache: dict[str, Optional[str]] = {}
+# extra API round trip on every call. The key is (account, calendar_id), not
+# calendar_id alone: 'primary' names a different calendar -- in a different
+# timezone -- for every signed-in account.
+_timezone_cache: dict[tuple, Optional[str]] = {}
 _timezone_lock = threading.Lock()
 
 
+def _creds_account(creds: Optional[Credentials]) -> str:
+    """The account name :class:`CredentialProvider` tagged these credentials with."""
+    return getattr(creds, "_calendar_mcp_account", None) or accounts.DEFAULT_ACCOUNT
+
+
 def _calendar_timezone(creds: Credentials, calendar_id: str) -> Optional[str]:
-    """Returns the IANA timezone of ``calendar_id``, cached per process."""
+    """Returns the IANA timezone of ``calendar_id``, cached per account."""
+    key = (_creds_account(creds), calendar_id)
     with _timezone_lock:
-        if calendar_id in _timezone_cache:
-            return _timezone_cache[calendar_id]
+        if key in _timezone_cache:
+            return _timezone_cache[key]
     tz = calendar_actions.get_calendar_timezone(creds, calendar_id)
     with _timezone_lock:
-        _timezone_cache[calendar_id] = tz
+        _timezone_cache[key] = tz
     return tz
+
+
+def _forget_calendar_timezone(calendar_id: Optional[str]) -> None:
+    """Drops a cached calendar timezone (e.g. after creating that calendar).
+
+    Every account's entry for ``calendar_id`` goes, which is the conservative
+    choice: re-reading a timezone costs one API call, serving a stale one costs
+    a wrongly-placed event.
+    """
+    if not calendar_id:
+        return
+    with _timezone_lock:
+        for key in [k for k in _timezone_cache if k[1] == calendar_id]:
+            _timezone_cache.pop(key, None)
 
 
 def _default_tzinfo(creds: Optional[Credentials], calendar_id: Optional[str]):
@@ -229,14 +331,11 @@ def _require(value: Optional[datetime], field: str) -> datetime:
 
 
 def _parse_clock(value: Optional[str], field: str) -> Optional[dt_time]:
-    """Parses an 'HH:MM' working-hours bound."""
-    if not value:
-        return None
+    """Parses an 'HH:MM' working-hours bound, as a tool-level error on failure."""
     try:
-        hour, _, minute = value.partition(":")
-        return dt_time(int(hour), int(minute or 0))
-    except (ValueError, TypeError) as exc:
-        raise CalendarToolError(f"{field} must look like 'HH:MM'; got {value!r}.") from exc
+        return parse_clock(value, field)
+    except ValueError as exc:
+        raise CalendarToolError(str(exc)) from exc
 
 
 # ---------------------------------------------------------------------------
@@ -293,6 +392,46 @@ def _no_result(action: str) -> CalendarToolError:
 
 
 # ---------------------------------------------------------------------------
+# Elicitation helpers
+# ---------------------------------------------------------------------------
+
+
+class DeleteConfirmation(BaseModel):
+    """Elicitation schema for a destructive tool's confirmation prompt."""
+
+    confirm: bool = Field(
+        default=False,
+        description="Confirm permanently deleting this event.",
+    )
+
+
+async def _confirm_delete(ctx: Optional[Context], label: str) -> Optional[bool]:
+    """Asks the client to confirm a deletion.
+
+    Returns True/False when the client answered, and None when the client does
+    not support elicitation (in which case the caller proceeds unprompted).
+    """
+    if ctx is None:
+        return None
+    try:
+        result = await ctx.elicit(
+            f"Permanently delete {label}? This cannot be undone.",
+            DeleteConfirmation,
+        )
+    except Exception as exc:  # client without elicitation support
+        logger.info("Skipping delete confirmation (client cannot elicit): %s", exc)
+        return None
+
+    action = getattr(result, "action", None)
+    if action == "accept":
+        data = getattr(result, "data", None)
+        return bool(getattr(data, "confirm", False))
+    if action in ("decline", "cancel"):
+        return False
+    return None
+
+
+# ---------------------------------------------------------------------------
 # Server + lifespan
 # ---------------------------------------------------------------------------
 
@@ -328,912 +467,13 @@ WRITE = ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHin
 UPDATE = ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=True)
 DESTRUCTIVE = ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=True, openWorldHint=True)
 
-
-# ---------------------------------------------------------------------------
-# Calendars
-# ---------------------------------------------------------------------------
-
-
-@server.tool(
-    name="list_calendars",
-    title="List calendars",
-    annotations=READ_ONLY,
+#: A local-only write (preferences on disk): not read-only, but it opens no
+#: world and re-applying it is harmless.
+LOCAL_WRITE = ToolAnnotations(
+    readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
 )
-async def list_calendars(
-    min_access_role: Optional[str] = None,
-    ctx: Optional[Context] = None,
-) -> CalendarListResult:
-    """List the calendars the signed-in user can see, with their IDs and timezones.
-
-    Start here whenever the user mentions a calendar other than their own: the
-    `id` values returned are what every other tool's `calendar_id` expects.
-
-    Args:
-        min_access_role: Only return calendars where the user has at least this
-            role: 'freeBusyReader', 'reader', 'writer' or 'owner'. Omit for all.
-    """
-    provider = _provider(ctx)
-
-    def work() -> CalendarListResult:
-        creds = provider.get()
-        response = calendar_actions.find_calendars(creds, min_access_role=min_access_role)
-        if response is None:
-            raise _no_result("Listing calendars")
-        calendars = [CalendarInfo.from_entry(entry) for entry in response.items]
-        return CalendarListResult(count=len(calendars), calendars=calendars)
-
-    return await _run(work)
-
-
-@server.tool(
-    name="create_calendar",
-    title="Create a calendar",
-    annotations=WRITE,
-)
-async def create_calendar(
-    summary: str,
-    ctx: Optional[Context] = None,
-) -> CalendarInfo:
-    """Create a new secondary calendar owned by the user.
-
-    Args:
-        summary: Name for the new calendar, e.g. 'Client work'.
-    """
-    provider = _provider(ctx)
-
-    def work() -> CalendarInfo:
-        creds = provider.get()
-        created = calendar_actions.create_calendar(creds, summary=summary)
-        if created is None:
-            raise _no_result("Creating the calendar")
-        # Drop any cached timezone under this brand-new ID.
-        with _timezone_lock:
-            _timezone_cache.pop(created.id, None)
-        return CalendarInfo.from_entry(created)
-
-    return await _run(work)
-
-
-# ---------------------------------------------------------------------------
-# Reading events
-# ---------------------------------------------------------------------------
-
-
-@server.tool(
-    name="find_events",
-    title="Find events",
-    annotations=READ_ONLY,
-)
-async def find_events(
-    calendar_id: str = "primary",
-    time_min: Optional[str] = None,
-    time_max: Optional[str] = None,
-    query: Optional[str] = None,
-    max_results: int = 50,
-    ctx: Optional[Context] = None,
-) -> EventListResult:
-    """Search a calendar for events, expanding recurring series into instances.
-
-    Use this before any tool that needs an `event_id`. Narrow the window with
-    `time_min`/`time_max` rather than raising `max_results`.
-
-    Args:
-        calendar_id: Calendar to search. 'primary' is the user's own calendar.
-        time_min: Inclusive start of the window, ISO 8601 with a UTC offset.
-            Without an offset it is read in the calendar's own timezone.
-        time_max: Exclusive end of the window, ISO 8601.
-        query: Free-text search over title, description, location and attendees.
-        max_results: Maximum events to return (default 50).
-    """
-    provider = _provider(ctx)
-
-    def work() -> EventListResult:
-        creds = provider.get()
-        response = calendar_actions.find_events(
-            credentials=creds,
-            calendar_id=calendar_id,
-            time_min=parse_datetime(time_min, "time_min", creds, calendar_id),
-            time_max=parse_datetime(time_max, "time_max", creds, calendar_id),
-            query=query,
-            max_results=max_results,
-        )
-        if response is None:
-            raise _no_result("Finding events")
-        events = [EventInfo.from_event(item) for item in response.items]
-        return EventListResult(
-            calendar_id=calendar_id,
-            count=len(events),
-            events=events,
-            time_zone=response.timeZone,
-        )
-
-    result = await _run(work)
-    if result.count >= max_results:
-        await _warn(
-            ctx,
-            f"find_events hit the max_results limit of {max_results}; there may be more "
-            "events in this window.",
-        )
-    return result
-
-
-@server.tool(
-    name="check_attendee_status",
-    title="Check attendee RSVPs",
-    annotations=READ_ONLY,
-)
-async def check_attendee_status(
-    event_id: str,
-    calendar_id: str = "primary",
-    attendee_emails: Optional[List[str]] = None,
-    ctx: Optional[Context] = None,
-) -> AttendeeStatusResult:
-    """Report who has accepted, declined or not yet answered an event invitation.
-
-    Args:
-        event_id: The event to inspect (from `find_events`).
-        calendar_id: Calendar the event lives on.
-        attendee_emails: Restrict the report to these addresses. Omit for all.
-    """
-    provider = _provider(ctx)
-
-    def work() -> AttendeeStatusResult:
-        creds = provider.get()
-        statuses = calendar_actions.check_attendee_status(
-            credentials=creds,
-            event_id=event_id,
-            calendar_id=calendar_id,
-            attendee_emails=attendee_emails,
-        )
-        if statuses is None:
-            raise _no_result("Checking attendee status")
-        entries = [
-            AttendeeStatusEntry(email=str(email), response_status=status)
-            for email, status in statuses.items()
-        ]
-        return AttendeeStatusResult(
-            calendar_id=calendar_id,
-            event_id=event_id,
-            count=len(entries),
-            attendees=entries,
-        )
-
-    return await _run(work)
-
-
-@server.tool(
-    name="query_free_busy",
-    title="Query free/busy",
-    annotations=READ_ONLY,
-)
-async def query_free_busy(
-    calendar_ids: List[str],
-    time_min: str,
-    time_max: str,
-    ctx: Optional[Context] = None,
-) -> FreeBusyResult:
-    """Get busy intervals for one or more calendars, without revealing event details.
-
-    Works for other people's calendars addressed by email, which is how you check
-    whether someone is free before proposing a time.
-
-    Args:
-        calendar_ids: Calendar IDs or attendee email addresses to check.
-        time_min: Start of the window, ISO 8601 with a UTC offset.
-        time_max: End of the window, ISO 8601 with a UTC offset.
-    """
-    provider = _provider(ctx)
-
-    def work() -> FreeBusyResult:
-        creds = provider.get()
-        start = _require(parse_datetime(time_min, "time_min", creds, "primary"), "time_min")
-        end = _require(parse_datetime(time_max, "time_max", creds, "primary"), "time_max")
-        raw = calendar_actions.find_availability(
-            credentials=creds,
-            time_min=start,
-            time_max=end,
-            calendar_ids=list(calendar_ids),
-        )
-        if raw is None:
-            raise _no_result("Querying free/busy")
-        calendars = []
-        for cal_id, data in raw.items():
-            calendars.append(
-                CalendarBusyPeriods(
-                    calendar_id=cal_id,
-                    busy=[
-                        BusyPeriod(
-                            start=interval["start"].isoformat(),
-                            end=interval["end"].isoformat(),
-                        )
-                        for interval in data.get("busy", [])
-                    ],
-                    errors=[
-                        err.get("reason", str(err)) if isinstance(err, dict) else str(err)
-                        for err in (data.get("errors") or [])
-                    ],
-                )
-            )
-        return FreeBusyResult(
-            time_min=start.isoformat(),
-            time_max=end.isoformat(),
-            calendars=calendars,
-        )
-
-    result = await _run(work)
-    unreadable = [c.calendar_id for c in result.calendars if c.errors]
-    if unreadable:
-        await _warn(ctx, f"Free/busy could not be read for: {', '.join(unreadable)}.")
-    return result
-
-
-@server.tool(
-    name="analyze_busyness",
-    title="Analyze calendar load",
-    annotations=READ_ONLY,
-)
-async def analyze_busyness(
-    time_min: str,
-    time_max: str,
-    calendar_id: str = "primary",
-    ctx: Optional[Context] = None,
-) -> BusynessResult:
-    """Summarise how loaded each day is: event count and total scheduled minutes.
-
-    Use this to answer "how busy is my week" without listing every event.
-
-    Args:
-        time_min: Start of the window, ISO 8601.
-        time_max: End of the window, ISO 8601.
-        calendar_id: Calendar to analyse.
-    """
-    provider = _provider(ctx)
-
-    def work() -> BusynessResult:
-        creds = provider.get()
-        start = _require(parse_datetime(time_min, "time_min", creds, calendar_id), "time_min")
-        end = _require(parse_datetime(time_max, "time_max", creds, calendar_id), "time_max")
-        stats = calendar_actions.get_busyness_analysis(
-            credentials=creds,
-            time_min=start,
-            time_max=end,
-            calendar_id=calendar_id,
-        )
-        if stats is None:
-            raise _no_result("Analysing busyness")
-        days = [
-            DayBusyness(
-                date=day.isoformat() if hasattr(day, "isoformat") else str(day),
-                event_count=int(values.get("event_count", 0)),
-                total_duration_minutes=float(values.get("total_duration_minutes", 0.0)),
-            )
-            for day, values in stats.items()
-        ]
-        return BusynessResult(
-            calendar_id=calendar_id,
-            time_min=start.isoformat(),
-            time_max=end.isoformat(),
-            days=days,
-            total_events=sum(d.event_count for d in days),
-            total_duration_minutes=sum(d.total_duration_minutes for d in days),
-        )
-
-    return await _run(work)
-
-
-@server.tool(
-    name="project_recurring_events",
-    title="Project recurring events",
-    annotations=READ_ONLY,
-)
-async def project_recurring_events(
-    time_min: str,
-    time_max: str,
-    calendar_id: str = "primary",
-    event_query: Optional[str] = None,
-    ctx: Optional[Context] = None,
-) -> ProjectedEventsResult:
-    """Compute future occurrences of recurring events from their recurrence rules.
-
-    Unlike `find_events`, this expands the RRULEs locally, so it reaches past the
-    horizon Google materialises instances for -- useful for "when do my birthdays
-    / standups land next year".
-
-    Args:
-        time_min: Start of the projection window, ISO 8601.
-        time_max: End of the projection window, ISO 8601.
-        calendar_id: Calendar whose recurring events should be projected.
-        event_query: Only project recurring events matching this text, e.g. 'Birthday'.
-    """
-    provider = _provider(ctx)
-
-    def work() -> ProjectedEventsResult:
-        creds = provider.get()
-        start = _require(parse_datetime(time_min, "time_min", creds, calendar_id), "time_min")
-        end = _require(parse_datetime(time_max, "time_max", creds, calendar_id), "time_max")
-        occurrences = calendar_actions.get_projected_recurring_events(
-            credentials=creds,
-            time_min=start,
-            time_max=end,
-            calendar_id=calendar_id,
-            event_query=event_query,
-        )
-        projected = [
-            ProjectedOccurrence(
-                event_id=item.original_event_id,
-                summary=item.original_summary,
-                start=item.occurrence_start.isoformat(),
-                end=item.occurrence_end.isoformat(),
-            )
-            for item in (occurrences or [])
-        ]
-        return ProjectedEventsResult(
-            calendar_id=calendar_id,
-            time_min=start.isoformat(),
-            time_max=end.isoformat(),
-            count=len(projected),
-            occurrences=projected,
-        )
-
-    return await _run(work)
-
-
-# ---------------------------------------------------------------------------
-# Writing events
-# ---------------------------------------------------------------------------
-
-
-@server.tool(
-    name="create_event",
-    title="Create an event",
-    annotations=WRITE,
-)
-async def create_event(
-    calendar_id: str = "primary",
-    summary: str = "",
-    start_time: str = "",
-    end_time: str = "",
-    description: Optional[str] = None,
-    location: Optional[str] = None,
-    attendee_emails: Optional[List[str]] = None,
-    send_notifications: bool = True,
-    ctx: Optional[Context] = None,
-) -> EventResult:
-    """Create an event with explicit start and end times, and optional attendees.
-
-    For a one-line natural-language description ("coffee with Sam tomorrow at 3")
-    prefer `quick_add_event`.
-
-    Args:
-        calendar_id: Calendar to create the event on.
-        summary: Event title. Required.
-        start_time: Start, ISO 8601 with a UTC offset (e.g. '2026-03-14T15:00:00-04:00').
-            Without an offset it is read in the calendar's own timezone.
-        end_time: End, ISO 8601, same convention as start_time.
-        description: Longer notes for the event body.
-        location: Free-text location or meeting link.
-        attendee_emails: People to invite. They receive an invitation email
-            unless send_notifications is false.
-        send_notifications: Whether Google emails the attendees. Default true.
-    """
-    provider = _provider(ctx)
-
-    def work() -> EventResult:
-        if not summary:
-            raise CalendarToolError("summary is required.")
-        creds = provider.get()
-        start = _require(parse_datetime(start_time, "start_time", creds, calendar_id), "start_time")
-        end = _require(parse_datetime(end_time, "end_time", creds, calendar_id), "end_time")
-        if end <= start:
-            raise CalendarToolError("end_time must be after start_time.")
-        request = EventCreateRequest(
-            summary=summary,
-            start=EventDateTime(dateTime=start),
-            end=EventDateTime(dateTime=end),
-            description=description,
-            location=location,
-            attendees=attendee_emails or None,
-        )
-        created = calendar_actions.create_event(
-            credentials=creds,
-            event_data=request,
-            calendar_id=calendar_id,
-            send_notifications=send_notifications,
-        )
-        if created is None:
-            raise _no_result("Creating the event")
-        return EventResult(
-            calendar_id=calendar_id,
-            event=EventInfo.from_event(created),
-            message=f"Created '{created.summary}' starting {start.isoformat()}.",
-        )
-
-    return await _run(work)
-
-
-@server.tool(
-    name="quick_add_event",
-    title="Quick-add an event",
-    annotations=WRITE,
-)
-async def quick_add_event(
-    text: str,
-    calendar_id: str = "primary",
-    ctx: Optional[Context] = None,
-) -> EventResult:
-    """Create an event from a plain-English phrase, parsed by Google.
-
-    Google interprets the date, time and title itself, in the calendar's own
-    timezone. Check the returned start/end and tell the user what was booked --
-    the parser guesses, and does not handle attendees or descriptions.
-
-    Args:
-        text: The phrase to parse, e.g. 'Dentist Thursday 9am' or
-            'Team sync every Monday at 10 for 30 minutes'.
-        calendar_id: Calendar to create the event on.
-    """
-    provider = _provider(ctx)
-
-    def work() -> EventResult:
-        if not text.strip():
-            raise CalendarToolError("text is required.")
-        creds = provider.get()
-        created = calendar_actions.quick_add_event(
-            credentials=creds,
-            text=text,
-            calendar_id=calendar_id,
-        )
-        if created is None:
-            raise _no_result("Quick-adding the event")
-        info = EventInfo.from_event(created)
-        return EventResult(
-            calendar_id=calendar_id,
-            event=info,
-            message=f"Google parsed {text!r} as '{info.summary}' starting {info.start}.",
-        )
-
-    return await _run(work)
-
-
-@server.tool(
-    name="update_event",
-    title="Update an event",
-    annotations=UPDATE,
-)
-async def update_event(
-    calendar_id: str = "primary",
-    event_id: str = "",
-    summary: Optional[str] = None,
-    start_time: Optional[str] = None,
-    end_time: Optional[str] = None,
-    description: Optional[str] = None,
-    location: Optional[str] = None,
-    send_notifications: bool = True,
-    ctx: Optional[Context] = None,
-) -> EventResult:
-    """Change fields on an existing event. Omitted fields are left untouched.
-
-    To reschedule while keeping the duration, use `move_event` instead: changing
-    only `start_time` here leaves the old end time in place.
-
-    Args:
-        calendar_id: Calendar the event lives on.
-        event_id: The event to update (from `find_events`). Required.
-        summary: New title.
-        start_time: New start, ISO 8601.
-        end_time: New end, ISO 8601.
-        description: New description.
-        location: New location.
-        send_notifications: Whether Google emails the attendees. Default true.
-    """
-    provider = _provider(ctx)
-
-    def work() -> EventResult:
-        if not event_id:
-            raise CalendarToolError("event_id is required.")
-        creds = provider.get()
-        start = parse_datetime(start_time, "start_time", creds, calendar_id)
-        end = parse_datetime(end_time, "end_time", creds, calendar_id)
-        if start and end and end <= start:
-            raise CalendarToolError("end_time must be after start_time.")
-        update = EventUpdateRequest(
-            summary=summary,
-            start=EventDateTime(dateTime=start) if start else None,
-            end=EventDateTime(dateTime=end) if end else None,
-            description=description,
-            location=location,
-        )
-        if not update.model_dump(exclude_none=True):
-            raise CalendarToolError(
-                "Nothing to update: pass at least one of summary, start_time, "
-                "end_time, description or location."
-            )
-        updated = calendar_actions.update_event(
-            credentials=creds,
-            event_id=event_id,
-            update_data=update,
-            calendar_id=calendar_id,
-            send_notifications=send_notifications,
-        )
-        if updated is None:
-            raise _no_result("Updating the event")
-        return EventResult(
-            calendar_id=calendar_id,
-            event=EventInfo.from_event(updated),
-            message=f"Updated event {event_id}.",
-        )
-
-    result = await _run(work)
-    if start_time and not end_time:
-        await _warn(
-            ctx,
-            "update_event changed only the start time; the end time is unchanged. "
-            "Use move_event to shift an event and keep its duration.",
-        )
-    return result
-
-
-@server.tool(
-    name="move_event",
-    title="Move or reschedule an event",
-    annotations=UPDATE,
-)
-async def move_event(
-    event_id: str,
-    calendar_id: str = "primary",
-    new_start: Optional[str] = None,
-    new_end: Optional[str] = None,
-    destination_calendar_id: Optional[str] = None,
-    send_notifications: bool = True,
-    ctx: Optional[Context] = None,
-) -> EventResult:
-    """Reschedule an event, and/or move it to a different calendar.
-
-    Supplying only `new_start` keeps the event's original duration -- this is the
-    right tool for "push my 2pm back an hour". Supplying
-    `destination_calendar_id` transfers the event between calendars.
-
-    Args:
-        event_id: The event to move (from `find_events`).
-        calendar_id: Calendar the event currently lives on.
-        new_start: New start, ISO 8601. Duration is preserved if new_end is omitted.
-        new_end: New end, ISO 8601. Optional when new_start is given.
-        destination_calendar_id: Calendar to transfer the event to.
-        send_notifications: Whether Google emails the attendees. Default true.
-    """
-    provider = _provider(ctx)
-
-    def work() -> EventResult:
-        if not event_id:
-            raise CalendarToolError("event_id is required.")
-        if not new_start and not new_end and not destination_calendar_id:
-            raise CalendarToolError(
-                "Pass at least one of new_start, new_end or destination_calendar_id."
-            )
-        creds = provider.get()
-        start = parse_datetime(new_start, "new_start", creds, calendar_id)
-        end = parse_datetime(new_end, "new_end", creds, calendar_id)
-        if start and end and end <= start:
-            raise CalendarToolError("new_end must be after new_start.")
-        moved = calendar_actions.move_event(
-            credentials=creds,
-            event_id=event_id,
-            calendar_id=calendar_id,
-            new_start=start,
-            new_end=end,
-            destination_calendar_id=destination_calendar_id,
-            send_notifications=send_notifications,
-        )
-        if moved is None:
-            raise _no_result("Moving the event")
-        info = EventInfo.from_event(moved)
-        where = destination_calendar_id or calendar_id
-        return EventResult(
-            calendar_id=where,
-            event=info,
-            message=f"Event {event_id} now runs {info.start} to {info.end} on '{where}'.",
-        )
-
-    result = await _run(work)
-    if new_start and not new_end and result.event.all_day:
-        await _warn(
-            ctx,
-            "This is an all-day event, so no duration could be preserved; "
-            "pass new_end explicitly if the length should change.",
-        )
-    return result
-
-
-@server.tool(
-    name="add_attendee",
-    title="Add attendees",
-    annotations=UPDATE,
-)
-async def add_attendee(
-    event_id: str,
-    attendee_emails: List[str],
-    calendar_id: str = "primary",
-    send_notifications: bool = True,
-    ctx: Optional[Context] = None,
-) -> EventResult:
-    """Invite one or more people to an existing event.
-
-    Existing attendees are kept; the new addresses are appended.
-
-    Args:
-        event_id: The event to invite people to (from `find_events`).
-        attendee_emails: Email addresses to invite.
-        calendar_id: Calendar the event lives on.
-        send_notifications: Whether Google emails the attendees. Default true.
-    """
-    provider = _provider(ctx)
-
-    def work() -> EventResult:
-        if not event_id:
-            raise CalendarToolError("event_id is required.")
-        if not attendee_emails:
-            raise CalendarToolError("attendee_emails must contain at least one address.")
-        creds = provider.get()
-        updated = calendar_actions.add_attendee(
-            credentials=creds,
-            event_id=event_id,
-            attendee_emails=list(attendee_emails),
-            calendar_id=calendar_id,
-            send_notifications=send_notifications,
-        )
-        if updated is None:
-            raise _no_result("Adding attendees")
-        return EventResult(
-            calendar_id=calendar_id,
-            event=EventInfo.from_event(updated),
-            message=f"Invited {', '.join(attendee_emails)} to event {event_id}.",
-        )
-
-    return await _run(work)
-
-
-@server.tool(
-    name="respond_to_event",
-    title="RSVP to an event",
-    annotations=UPDATE,
-)
-async def respond_to_event(
-    event_id: str,
-    response_status: str,
-    calendar_id: str = "primary",
-    comment: Optional[str] = None,
-    send_notifications: bool = True,
-    ctx: Optional[Context] = None,
-) -> EventResult:
-    """Set the user's own RSVP on an invitation they have received.
-
-    Only works on events the user is an attendee of; it does not change anyone
-    else's response.
-
-    Args:
-        event_id: The invitation to answer (from `find_events`).
-        response_status: 'accepted', 'declined', 'tentative' or 'needsAction'.
-        calendar_id: Calendar the invitation lives on.
-        comment: Optional note sent to the organizer with the RSVP.
-        send_notifications: Whether Google emails the organizer. Default true.
-    """
-    provider = _provider(ctx)
-
-    def work() -> EventResult:
-        if not event_id:
-            raise CalendarToolError("event_id is required.")
-        creds = provider.get()
-        updated = calendar_actions.respond_to_event(
-            credentials=creds,
-            event_id=event_id,
-            response_status=response_status,
-            calendar_id=calendar_id,
-            comment=comment,
-            send_notifications=send_notifications,
-        )
-        if updated is None:
-            raise _no_result("Responding to the event")
-        return EventResult(
-            calendar_id=calendar_id,
-            event=EventInfo.from_event(updated),
-            message=f"RSVP for event {event_id} set to '{response_status}'.",
-        )
-
-    return await _run(work)
-
-
-@server.tool(
-    name="schedule_mutual",
-    title="Find a mutual slot and schedule",
-    annotations=WRITE,
-)
-async def schedule_mutual(
-    attendee_calendar_ids: List[str],
-    time_min: str,
-    time_max: str,
-    duration_minutes: int,
-    summary: str,
-    description: Optional[str] = None,
-    location: Optional[str] = None,
-    organizer_calendar_id: str = "primary",
-    working_hours_start: Optional[str] = None,
-    working_hours_end: Optional[str] = None,
-    send_notifications: bool = True,
-    ctx: Optional[Context] = None,
-) -> EventResult:
-    """Find the first slot where everyone is free, then book the meeting there.
-
-    Reads each attendee's free/busy inside the window, picks the earliest gap
-    that fits `duration_minutes`, and creates the event with all of them invited.
-    Fails with an error if no common slot exists -- widen the window or shorten
-    the meeting and try again.
-
-    Args:
-        attendee_calendar_ids: Attendee email addresses whose availability matters.
-        time_min: Earliest the meeting may start, ISO 8601 with a UTC offset.
-        time_max: Latest the meeting may end, ISO 8601 with a UTC offset.
-        duration_minutes: Length of the meeting in minutes.
-        summary: Title for the meeting.
-        description: Optional agenda or notes.
-        location: Optional location or meeting link.
-        organizer_calendar_id: Calendar the meeting is created on.
-        working_hours_start: Optional daily earliest start, 'HH:MM' local to the
-            calendar, e.g. '09:00'.
-        working_hours_end: Optional daily latest end, 'HH:MM', e.g. '17:00'.
-        send_notifications: Whether Google emails the attendees. Default true.
-    """
-    provider = _provider(ctx)
-
-    def work() -> EventResult:
-        if duration_minutes <= 0:
-            raise CalendarToolError("duration_minutes must be greater than zero.")
-        if not attendee_calendar_ids:
-            raise CalendarToolError("attendee_calendar_ids must contain at least one address.")
-        creds = provider.get()
-        start = _require(
-            parse_datetime(time_min, "time_min", creds, organizer_calendar_id), "time_min"
-        )
-        end = _require(
-            parse_datetime(time_max, "time_max", creds, organizer_calendar_id), "time_max"
-        )
-        if end - start < timedelta(minutes=duration_minutes):
-            raise CalendarToolError(
-                "The search window is shorter than duration_minutes; widen time_min/time_max."
-            )
-        placeholder = EventDateTime(dateTime=start)
-        details = EventCreateRequest(
-            summary=summary,
-            start=placeholder,
-            end=placeholder,
-            description=description,
-            location=location,
-        )
-        created = calendar_actions.find_mutual_availability_and_schedule(
-            credentials=creds,
-            attendee_calendar_ids=list(attendee_calendar_ids),
-            time_min=start,
-            time_max=end,
-            duration_minutes=duration_minutes,
-            event_details=details,
-            organizer_calendar_id=organizer_calendar_id,
-            working_hours_start=_parse_clock(working_hours_start, "working_hours_start"),
-            working_hours_end=_parse_clock(working_hours_end, "working_hours_end"),
-            send_notifications=send_notifications,
-        )
-        if created is None:
-            raise CalendarToolError(
-                f"No {duration_minutes}-minute slot is free for everyone between "
-                f"{start.isoformat()} and {end.isoformat()}. Widen the window, shorten "
-                "the meeting, or relax the working-hours bounds."
-            )
-        info = EventInfo.from_event(created)
-        return EventResult(
-            calendar_id=organizer_calendar_id,
-            event=info,
-            message=f"Booked '{summary}' at {info.start} with {len(attendee_calendar_ids)} attendee(s).",
-        )
-
-    return await _run(work)
-
-
-# ---------------------------------------------------------------------------
-# Deleting events (with optional confirmation)
-# ---------------------------------------------------------------------------
-
-
-class DeleteConfirmation(BaseModel):
-    """Elicitation schema for the delete_event confirmation prompt."""
-
-    confirm: bool = Field(
-        default=False,
-        description="Confirm permanently deleting this event.",
-    )
-
-
-async def _confirm_delete(ctx: Optional[Context], label: str) -> Optional[bool]:
-    """Asks the client to confirm a deletion.
-
-    Returns True/False when the client answered, and None when the client does
-    not support elicitation (in which case the caller proceeds unprompted).
-    """
-    if ctx is None:
-        return None
-    try:
-        result = await ctx.elicit(
-            f"Permanently delete {label}? This cannot be undone.",
-            DeleteConfirmation,
-        )
-    except Exception as exc:  # client without elicitation support
-        logger.info("Skipping delete confirmation (client cannot elicit): %s", exc)
-        return None
-
-    action = getattr(result, "action", None)
-    if action == "accept":
-        data = getattr(result, "data", None)
-        return bool(getattr(data, "confirm", False))
-    if action in ("decline", "cancel"):
-        return False
-    return None
-
-
-@server.tool(
-    name="delete_event",
-    title="Delete an event",
-    annotations=DESTRUCTIVE,
-)
-async def delete_event(
-    event_id: str,
-    calendar_id: str = "primary",
-    send_notifications: bool = True,
-    ctx: Optional[Context] = None,
-) -> DeleteEventResult:
-    """Permanently delete an event. This cannot be undone.
-
-    Clients that support elicitation are asked to confirm first; if the user
-    declines, nothing is deleted and `deleted` comes back false.
-
-    Args:
-        event_id: The event to delete (from `find_events`).
-        calendar_id: Calendar the event lives on.
-        send_notifications: Whether Google emails the attendees that it was
-            cancelled. Default true.
-    """
-    if not event_id:
-        raise CalendarToolError("event_id is required.")
-
-    confirmed = await _confirm_delete(ctx, f"event {event_id} on calendar '{calendar_id}'")
-    if confirmed is False:
-        return DeleteEventResult(
-            calendar_id=calendar_id,
-            event_id=event_id,
-            deleted=False,
-            confirmed_by_user=False,
-            message="Deletion cancelled by the user; nothing was changed.",
-        )
-
-    provider = _provider(ctx)
-
-    def work() -> bool:
-        creds = provider.get()
-        return bool(
-            calendar_actions.delete_event(
-                credentials=creds,
-                event_id=event_id,
-                calendar_id=calendar_id,
-                send_notifications=send_notifications,
-            )
-        )
-
-    deleted = await _run(work)
-    if not deleted:
-        raise _no_result("Deleting the event")
-    return DeleteEventResult(
-        calendar_id=calendar_id,
-        event_id=event_id,
-        deleted=True,
-        confirmed_by_user=confirmed,
-        message=f"Deleted event {event_id} from '{calendar_id}'.",
-    )
+#: A local-only read (accounts, preferences): no Google call at all.
+LOCAL_READ = ToolAnnotations(readOnlyHint=True, idempotentHint=True, openWorldHint=False)
 
 
 # ---------------------------------------------------------------------------
@@ -1263,18 +503,108 @@ def http_app(path: str = "/mcp", host: str = "127.0.0.1"):
     return server.streamable_http_app(streamable_http_path=path, host=host)
 
 
+# ---------------------------------------------------------------------------
+# Tool registration
+#
+# Importing the package runs every tool module, each of which decorates its
+# functions with ``@server.tool(...)``. This is the last statement in the file
+# on purpose: by the time the tool modules do ``from calendar_mcp import server
+# as srv``, everything above already exists. Python's module cache guarantees
+# each tool is registered exactly once, however the package is first imported.
+# ---------------------------------------------------------------------------
+
+from calendar_mcp import tools as _tools  # noqa: E402  (registers the tools)
+
+
+def __getattr__(name: str):
+    """Resolves ``server.<tool>`` to the tool function in ``calendar_mcp.tools``.
+
+    Every tool stays reachable from this module -- ``server.find_events`` still
+    works, as do the tests that call the tool functions directly -- without
+    listing them here. The lookup is lazy on purpose: importing
+    ``calendar_mcp.tools`` first would otherwise hit this module mid-import and
+    fail on a half-built tools module. Resolved names are cached in globals, so
+    the scan happens at most once per tool.
+
+    Only functions defined inside ``calendar_mcp.tools`` are resolvable, so a
+    typo cannot silently hand back some helper a tool module imported.
+    """
+    if name.startswith("__"):
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    import importlib
+
+    package = importlib.import_module("calendar_mcp.tools")
+    for submodule in getattr(package, "__all__", ()):
+        module = importlib.import_module(f"calendar_mcp.tools.{submodule}")
+        value = getattr(module, name, None)
+        if callable(value) and getattr(value, "__module__", "").startswith("calendar_mcp.tools"):
+            globals()[name] = value
+            return value
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 __all__ = [
+    # server plumbing
     "server",
     "AppContext",
     "CalendarToolError",
     "CredentialProvider",
     "credential_provider",
     "lifespan",
-    "parse_datetime",
     "run_stdio",
     "run_http",
     "http_app",
     "INSTRUCTIONS",
     "SERVER_NAME",
     "SERVER_VERSION",
+    "ACCOUNT_ARG_DOC",
+    # annotations
+    "READ_ONLY",
+    "WRITE",
+    "UPDATE",
+    "DESTRUCTIVE",
+    "LOCAL_READ",
+    "LOCAL_WRITE",
+    # time helpers (credential-aware here, pure ones in calendar_mcp.timeutil)
+    "parse_datetime",
+    "Interval",
+    "clip_intervals",
+    "combine",
+    "format_clock",
+    "free_windows",
+    "iter_days",
+    "merge_intervals",
+    "parse_clock",
+    "subtract_intervals",
+    # modules the tools reach Google and config through
+    "accounts",
+    "auth",
+    "calendar_actions",
+    "preferences",
+    # tools
+    "add_attendee",
+    "analyze_busyness",
+    "block_focus_time",
+    "check_attendee_status",
+    "create_calendar",
+    "create_event",
+    "delete_event",
+    "detect_conflicts",
+    "find_events",
+    "find_focus_time",
+    "get_preferences",
+    "list_accounts",
+    "list_calendars",
+    "move_event",
+    "project_recurring_events",
+    "query_free_busy",
+    "quick_add_event",
+    "respond_to_event",
+    "schedule_mutual",
+    "set_preferences",
+    "suggest_reschedule",
+    "time_audit",
+    "update_event",
 ]

--- a/calendar_mcp/timeutil.py
+++ b/calendar_mcp/timeutil.py
@@ -1,0 +1,182 @@
+"""Timezone- and interval-arithmetic helpers shared by the scheduling tools.
+
+Everything in this module is pure: no Google client, no credentials, no disk.
+That makes it safe to import from anywhere (including
+:mod:`calendar_mcp.preferences`) and cheap to unit-test.
+
+The credential-aware timestamp helpers -- :func:`calendar_mcp.server.parse_datetime`
+and :func:`calendar_mcp.server._default_tzinfo` -- stay in
+:mod:`calendar_mcp.server`, because they need the calendar-timezone lookup and
+its per-process cache. Import them from there; import the interval maths from
+here.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, time as dt_time, timedelta
+from typing import Iterable, Iterator, List, Optional, Sequence, Tuple
+
+__all__ = [
+    "Interval",
+    "parse_clock",
+    "format_clock",
+    "merge_intervals",
+    "subtract_intervals",
+    "clip_intervals",
+    "free_windows",
+    "iter_days",
+    "combine",
+]
+
+#: An aware (start, end) pair. Every helper here assumes ``start <= end`` and
+#: that both ends carry a tzinfo; comparisons across zones are fine.
+Interval = Tuple[datetime, datetime]
+
+
+# ---------------------------------------------------------------------------
+# Clock strings
+# ---------------------------------------------------------------------------
+
+
+def parse_clock(value: Optional[str], field: str = "time") -> Optional[dt_time]:
+    """Parses an ``'HH:MM'`` wall-clock string into a :class:`datetime.time`.
+
+    Args:
+        value: The string to parse. ``None`` or ``''`` returns ``None``.
+        field: Name used in the error message.
+
+    Returns:
+        The parsed time, or ``None`` when ``value`` is empty.
+
+    Raises:
+        ValueError: If the string is not ``HH:MM`` in range.
+    """
+    if not value:
+        return None
+    text = str(value).strip()
+    hour_text, sep, minute_text = text.partition(":")
+    try:
+        hour = int(hour_text)
+        minute = int(minute_text) if sep else 0
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field} must look like 'HH:MM'; got {value!r}.") from exc
+    if not (0 <= hour <= 23 and 0 <= minute <= 59):
+        raise ValueError(f"{field} must be between '00:00' and '23:59'; got {value!r}.")
+    return dt_time(hour, minute)
+
+
+def format_clock(value: dt_time) -> str:
+    """Renders a :class:`datetime.time` back as ``'HH:MM'``."""
+    return f"{value.hour:02d}:{value.minute:02d}"
+
+
+# ---------------------------------------------------------------------------
+# Interval arithmetic
+# ---------------------------------------------------------------------------
+
+
+def merge_intervals(intervals: Iterable[Interval]) -> List[Interval]:
+    """Sorts and coalesces overlapping or touching intervals.
+
+    Zero-length and inverted intervals are dropped.
+    """
+    ordered = sorted(
+        ((start, end) for start, end in intervals if end > start),
+        key=lambda pair: pair[0],
+    )
+    merged: List[Interval] = []
+    for start, end in ordered:
+        if merged and start <= merged[-1][1]:
+            if end > merged[-1][1]:
+                merged[-1] = (merged[-1][0], end)
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def subtract_intervals(base: Interval, cuts: Iterable[Interval]) -> List[Interval]:
+    """Removes ``cuts`` from the single interval ``base``.
+
+    Returns the remaining pieces in chronological order (possibly empty).
+    """
+    start, end = base
+    if end <= start:
+        return []
+    remaining: List[Interval] = []
+    cursor = start
+    for cut_start, cut_end in merge_intervals(cuts):
+        if cut_end <= cursor:
+            continue
+        if cut_start >= end:
+            break
+        if cut_start > cursor:
+            remaining.append((cursor, min(cut_start, end)))
+        cursor = max(cursor, cut_end)
+        if cursor >= end:
+            break
+    if cursor < end:
+        remaining.append((cursor, end))
+    return [(a, b) for a, b in remaining if b > a]
+
+
+def clip_intervals(intervals: Iterable[Interval], window: Interval) -> List[Interval]:
+    """Trims every interval to ``window``, dropping the ones that fall outside."""
+    low, high = window
+    clipped: List[Interval] = []
+    for start, end in intervals:
+        new_start, new_end = max(start, low), min(end, high)
+        if new_end > new_start:
+            clipped.append((new_start, new_end))
+    return clipped
+
+
+def free_windows(
+    busy: Sequence[Interval],
+    window: Interval,
+    buffer_minutes: int = 0,
+) -> List[Interval]:
+    """Returns the gaps inside ``window`` that no busy interval covers.
+
+    Each busy interval is first grown by ``buffer_minutes`` on both sides, so a
+    caller that wants breathing room around meetings gets free windows that
+    already respect it. The result is clipped to ``window`` and merged, so the
+    pieces are disjoint and in chronological order.
+
+    Args:
+        busy: Busy ``(start, end)`` pairs, in any order; overlaps are fine.
+        window: The ``(start, end)`` range to search inside.
+        buffer_minutes: Minimum gap to leave before and after each busy block.
+
+    Returns:
+        The free ``(start, end)`` pairs, earliest first. Empty when the window
+        is fully booked (or inverted).
+    """
+    pad = timedelta(minutes=max(0, int(buffer_minutes or 0)))
+    padded = [(start - pad, end + pad) for start, end in busy if end > start]
+    return subtract_intervals(window, padded)
+
+
+# ---------------------------------------------------------------------------
+# Day iteration
+# ---------------------------------------------------------------------------
+
+
+def iter_days(time_min: datetime, time_max: datetime, tzinfo) -> Iterator[date]:
+    """Yields every local calendar date touched by ``[time_min, time_max)``.
+
+    Both bounds are converted into ``tzinfo`` first, so "which days does this
+    window cover" is answered in the user's own zone rather than in UTC.
+    """
+    if time_max <= time_min:
+        return
+    start = time_min.astimezone(tzinfo).date()
+    end = time_max.astimezone(tzinfo).date()
+    current = start
+    while current <= end:
+        yield current
+        current += timedelta(days=1)
+
+
+def combine(day: date, clock: dt_time, tzinfo) -> datetime:
+    """Builds an aware datetime for ``clock`` on ``day`` in ``tzinfo``."""
+    return datetime.combine(day, clock).replace(tzinfo=tzinfo)

--- a/calendar_mcp/tools/__init__.py
+++ b/calendar_mcp/tools/__init__.py
@@ -1,0 +1,94 @@
+"""Every MCP tool calendar-mcp exposes, one module per subject area.
+
+Importing this package registers all of them against the ``MCPServer``
+instance in :mod:`calendar_mcp.server`; :mod:`calendar_mcp.server` imports it
+as its very last statement, so ``import calendar_mcp.server`` is all any entry
+point needs.
+
+Layout:
+
+===========================  ================================================
+``calendar_mcp.tools``       tools
+===========================  ================================================
+:mod:`~calendar_mcp.tools.accounts`     ``list_accounts``, ``get_preferences``,
+                                        ``set_preferences``
+:mod:`~calendar_mcp.tools.analysis`     ``analyze_busyness``,
+                                        ``project_recurring_events``
+:mod:`~calendar_mcp.tools.calendars`    ``list_calendars``, ``create_calendar``
+:mod:`~calendar_mcp.tools.conflicts`    ``detect_conflicts``, ``suggest_reschedule``
+:mod:`~calendar_mcp.tools.events`       ``find_events``, ``check_attendee_status``,
+                                        ``create_event``, ``quick_add_event``,
+                                        ``update_event``, ``move_event``,
+                                        ``add_attendee``, ``respond_to_event``,
+                                        ``delete_event``
+:mod:`~calendar_mcp.tools.focus`        ``find_focus_time``, ``block_focus_time``
+:mod:`~calendar_mcp.tools.scheduling`   ``query_free_busy``, ``schedule_mutual``
+===========================  ================================================
+
+**Adding a tool.** Put it in whichever module fits (or add a new one and list
+it in the import below -- that is the only edit outside your own file). The
+pattern every tool follows:
+
+.. code-block:: python
+
+    from typing import Optional
+
+    from calendar_mcp import server as srv
+
+
+    @srv.server.tool(name="my_tool", title="My tool", annotations=srv.READ_ONLY)
+    async def my_tool(
+        calendar_id: str = "primary",
+        account: Optional[str] = None,
+        ctx: Optional[srv.Context] = None,
+    ) -> SomeResultModel:
+        \"\"\"What the tool does, as the model will read it.
+
+        Args:
+            calendar_id: Calendar to read.
+            account: Account name from 'calendar-mcp accounts'; omit for the default.
+        \"\"\"
+        provider = srv._provider(ctx)
+
+        def work() -> SomeResultModel:
+            creds = provider.get(account)
+            response = srv.calendar_actions.something(creds, ...)
+            if response is None:
+                raise srv._no_result("Doing the thing")
+            return SomeResultModel(...)
+
+        return await srv._run(work)
+
+Three rules keep the suite green and the tools consistent:
+
+1. Blocking Google work goes inside a ``work()`` closure handed to
+   ``srv._run``, which moves it off the event loop and turns ``HttpError`` /
+   ``AuthError`` / ``ValueError`` into :class:`~calendar_mcp.server.CalendarToolError`.
+2. Reach Google through ``srv.calendar_actions``, never by importing
+   ``calendar_actions`` directly -- the tests patch that attribute.
+3. Give the tool a trailing ``account: Optional[str] = None`` and pass it to
+   ``provider.get(account)``, then document it with
+   :data:`~calendar_mcp.server.ACCOUNT_ARG_DOC`'s wording.
+"""
+
+from calendar_mcp.tools import (  # noqa: F401
+    accounts,
+    analysis,
+    audit,
+    calendars,
+    conflicts,
+    events,
+    focus,
+    scheduling,
+)
+
+__all__ = [
+    "accounts",
+    "analysis",
+    "audit",
+    "calendars",
+    "conflicts",
+    "events",
+    "focus",
+    "scheduling",
+]

--- a/calendar_mcp/tools/accounts.py
+++ b/calendar_mcp/tools/accounts.py
@@ -1,0 +1,157 @@
+"""Tools for the local configuration: signed-in accounts and scheduling preferences.
+
+Nothing here calls Google. ``list_accounts`` reads the token directory,
+``get_preferences``/``set_preferences`` read and write one JSON file, so all
+three answer instantly and work even when every token has expired.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from pydantic import ValidationError
+
+from calendar_mcp import accounts as accounts_module
+from calendar_mcp import preferences as preferences_module
+from calendar_mcp import server as srv
+from calendar_mcp.models import AccountListResult
+from calendar_mcp.preferences import Preferences, TimeRange
+
+
+def _readable_validation_error(exc: ValidationError) -> str:
+    """Turns a pydantic ValidationError into one line per bad field."""
+    parts = []
+    for error in exc.errors():
+        location = ".".join(str(item) for item in error.get("loc", ())) or "value"
+        message = str(error.get("msg", "is invalid"))
+        # pydantic prefixes custom validator messages with "Value error, ".
+        if message.startswith("Value error, "):
+            message = message[len("Value error, "):]
+        parts.append(f"{location}: {message}")
+    return "; ".join(parts) or str(exc)
+
+
+@srv.server.tool(
+    name="list_accounts",
+    title="List signed-in accounts",
+    annotations=srv.LOCAL_READ,
+)
+async def list_accounts(
+    ctx: Optional[srv.Context] = None,
+) -> AccountListResult:
+    """List the Google accounts calendar-mcp can use, and which is the default.
+
+    Every other tool takes an optional `account` argument naming one of these.
+    An account whose `valid` is false needs `calendar-mcp auth --account <name>`
+    run once in a terminal before its calendars can be read.
+    """
+
+    def work() -> AccountListResult:
+        infos = accounts_module.list_accounts()
+        return AccountListResult(
+            count=len(infos),
+            default_account=accounts_module.resolve_account(None),
+            config_dir=str(accounts_module.config_dir()),
+            accounts=infos,
+        )
+
+    return await srv._run(work)
+
+
+@srv.server.tool(
+    name="get_preferences",
+    title="Get scheduling preferences",
+    annotations=srv.LOCAL_READ,
+)
+async def get_preferences(
+    ctx: Optional[srv.Context] = None,
+) -> Preferences:
+    """Read the user's scheduling preferences: working hours, lunch, buffers, focus.
+
+    Consult this before proposing meeting times or hunting for focus blocks,
+    rather than assuming a nine-to-five. Never configured returns the defaults
+    (Mon-Fri 09:00-17:00, no lunch break, no buffer), which is a reasonable
+    guess but worth confirming with the user before you rely on it.
+    """
+
+    def work() -> Preferences:
+        return preferences_module.load()
+
+    return await srv._run(work)
+
+
+@srv.server.tool(
+    name="set_preferences",
+    title="Set scheduling preferences",
+    annotations=srv.LOCAL_WRITE,
+)
+async def set_preferences(
+    timezone: Optional[str] = None,
+    working_hours: Optional[Dict[str, List[TimeRange]]] = None,
+    buffer_minutes: Optional[int] = None,
+    min_focus_block_minutes: Optional[int] = None,
+    lunch: Optional[TimeRange] = None,
+    focus_calendar_id: Optional[str] = None,
+    clear_lunch: bool = False,
+    ctx: Optional[srv.Context] = None,
+) -> Preferences:
+    """Update the user's scheduling preferences and save them. Returns the merged result.
+
+    Only the arguments you pass change; everything else keeps its current value,
+    so a single correction ("I actually start at 8") does not have to restate
+    the whole schedule. The merged result is validated before it is written, so
+    a rejected change leaves the saved preferences untouched.
+
+    Args:
+        timezone: IANA timezone the working hours are expressed in, e.g.
+            'Europe/Berlin'. Must be a real zone name.
+        working_hours: Whole-schedule replacement, keyed by weekday
+            ('mon'..'sun'), each value a list of ['HH:MM', 'HH:MM'] pairs. Days
+            you omit become non-working, so pass every working day at once, e.g.
+            {"mon": [["09:00", "12:00"], ["13:00", "18:00"]], "fri": [["09:00", "15:00"]]}.
+        buffer_minutes: Minimum gap to leave before and after each meeting when
+            proposing times. 0 disables it.
+        min_focus_block_minutes: Shortest free stretch that still counts as
+            usable focus time.
+        lunch: Daily lunch break as ['HH:MM', 'HH:MM'], carved out of the
+            working hours.
+        focus_calendar_id: Calendar that focus blocks are booked on; 'primary'
+            for the user's own.
+        clear_lunch: Set true to remove an existing lunch break (pass this
+            instead of `lunch` when the user says they no longer want one).
+    """
+
+    def work() -> Preferences:
+        updates = {
+            "timezone": timezone,
+            "working_hours": working_hours,
+            "buffer_minutes": buffer_minutes,
+            "min_focus_block_minutes": min_focus_block_minutes,
+            "lunch": list(lunch) if lunch is not None else None,
+            "focus_calendar_id": focus_calendar_id,
+        }
+        if not clear_lunch and all(value is None for value in updates.values()):
+            raise srv.CalendarToolError(
+                "Nothing to change: pass at least one of timezone, working_hours, "
+                "buffer_minutes, min_focus_block_minutes, lunch, focus_calendar_id "
+                "or clear_lunch."
+            )
+        if clear_lunch and lunch is not None:
+            raise srv.CalendarToolError("Pass either lunch or clear_lunch, not both.")
+
+        current = preferences_module.load()
+        try:
+            merged = preferences_module.merge(current, **updates)
+            if clear_lunch:
+                merged = merged.model_copy(update={"lunch": None})
+        except ValidationError as exc:
+            raise srv.CalendarToolError(
+                f"Those preferences are not valid -- {_readable_validation_error(exc)}"
+            ) from exc
+        except ValueError as exc:
+            raise srv.CalendarToolError(f"Those preferences are not valid -- {exc}") from exc
+
+        preferences_module.save(merged)
+        return merged
+
+    return await srv._run(work)

--- a/calendar_mcp/tools/analysis.py
+++ b/calendar_mcp/tools/analysis.py
@@ -1,0 +1,132 @@
+"""Tools that summarise a calendar rather than listing it."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from calendar_mcp import server as srv
+from calendar_mcp.models import (
+    BusynessResult,
+    DayBusyness,
+    ProjectedEventsResult,
+    ProjectedOccurrence,
+)
+
+
+@srv.server.tool(
+    name="analyze_busyness",
+    title="Analyze calendar load",
+    annotations=srv.READ_ONLY,
+)
+async def analyze_busyness(
+    time_min: str,
+    time_max: str,
+    calendar_id: str = "primary",
+    account: Optional[str] = None,
+    ctx: Optional[srv.Context] = None,
+) -> BusynessResult:
+    """Summarise how loaded each day is: event count and total scheduled minutes.
+
+    Use this to answer "how busy is my week" without listing every event.
+
+    Args:
+        time_min: Start of the window, ISO 8601.
+        time_max: End of the window, ISO 8601.
+        calendar_id: Calendar to analyse.
+        account: Account name from 'calendar-mcp accounts'; omit for the default.
+    """
+    provider = srv._provider(ctx)
+
+    def work() -> BusynessResult:
+        creds = provider.get(account)
+        start = srv._require(
+            srv.parse_datetime(time_min, "time_min", creds, calendar_id), "time_min"
+        )
+        end = srv._require(srv.parse_datetime(time_max, "time_max", creds, calendar_id), "time_max")
+        stats = srv.calendar_actions.get_busyness_analysis(
+            credentials=creds,
+            time_min=start,
+            time_max=end,
+            calendar_id=calendar_id,
+        )
+        if stats is None:
+            raise srv._no_result("Analysing busyness")
+        days = [
+            DayBusyness(
+                date=day.isoformat() if hasattr(day, "isoformat") else str(day),
+                event_count=int(values.get("event_count", 0)),
+                total_duration_minutes=float(values.get("total_duration_minutes", 0.0)),
+            )
+            for day, values in stats.items()
+        ]
+        return BusynessResult(
+            calendar_id=calendar_id,
+            time_min=start.isoformat(),
+            time_max=end.isoformat(),
+            days=days,
+            total_events=sum(d.event_count for d in days),
+            total_duration_minutes=sum(d.total_duration_minutes for d in days),
+        )
+
+    return await srv._run(work)
+
+
+@srv.server.tool(
+    name="project_recurring_events",
+    title="Project recurring events",
+    annotations=srv.READ_ONLY,
+)
+async def project_recurring_events(
+    time_min: str,
+    time_max: str,
+    calendar_id: str = "primary",
+    event_query: Optional[str] = None,
+    account: Optional[str] = None,
+    ctx: Optional[srv.Context] = None,
+) -> ProjectedEventsResult:
+    """Compute future occurrences of recurring events from their recurrence rules.
+
+    Unlike `find_events`, this expands the RRULEs locally, so it reaches past the
+    horizon Google materialises instances for -- useful for "when do my birthdays
+    / standups land next year".
+
+    Args:
+        time_min: Start of the projection window, ISO 8601.
+        time_max: End of the projection window, ISO 8601.
+        calendar_id: Calendar whose recurring events should be projected.
+        event_query: Only project recurring events matching this text, e.g. 'Birthday'.
+        account: Account name from 'calendar-mcp accounts'; omit for the default.
+    """
+    provider = srv._provider(ctx)
+
+    def work() -> ProjectedEventsResult:
+        creds = provider.get(account)
+        start = srv._require(
+            srv.parse_datetime(time_min, "time_min", creds, calendar_id), "time_min"
+        )
+        end = srv._require(srv.parse_datetime(time_max, "time_max", creds, calendar_id), "time_max")
+        occurrences = srv.calendar_actions.get_projected_recurring_events(
+            credentials=creds,
+            time_min=start,
+            time_max=end,
+            calendar_id=calendar_id,
+            event_query=event_query,
+        )
+        projected = [
+            ProjectedOccurrence(
+                event_id=item.original_event_id,
+                summary=item.original_summary,
+                start=item.occurrence_start.isoformat(),
+                end=item.occurrence_end.isoformat(),
+            )
+            for item in (occurrences or [])
+        ]
+        return ProjectedEventsResult(
+            calendar_id=calendar_id,
+            time_min=start.isoformat(),
+            time_max=end.isoformat(),
+            count=len(projected),
+            occurrences=projected,
+        )
+
+    return await srv._run(work)

--- a/calendar_mcp/tools/audit.py
+++ b/calendar_mcp/tools/audit.py
@@ -1,0 +1,114 @@
+"""The ``time_audit`` tool: a retrospective on where the user's time went.
+
+The Google call here is deliberately thin -- fetch the events, normalise them,
+and hand the list to :func:`calendar_mcp.audit.build_audit`, which does all the
+arithmetic offline and is tested without a network.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+try:  # Python 3.8+ typing shim; the SDK reads this off the signature.
+    from typing import Literal
+except ImportError:  # pragma: no cover - 3.8+ always has it
+    Literal = None  # type: ignore[assignment]
+
+from calendar_mcp import audit as audit_logic
+from calendar_mcp import preferences as preferences_module
+from calendar_mcp import server as srv
+from calendar_mcp.models import TimeAuditResult
+
+#: Fetched per calendar. Google caps a single events.list page at 2500.
+MAX_EVENTS_PER_CALENDAR = 2500
+
+
+@srv.server.tool(
+    name="time_audit",
+    title="Audit where time went",
+    annotations=srv.READ_ONLY,
+)
+async def time_audit(
+    time_min: str,
+    time_max: str,
+    calendar_ids: Optional[List[str]] = None,
+    group_by: Literal["day", "week"] = "week",
+    include_all_day: bool = False,
+    include_declined: bool = False,
+    account: Optional[str] = None,
+    ctx: Optional[srv.Context] = None,
+) -> TimeAuditResult:
+    """Report where the user's time went: meeting hours, who with, and what focus time is left.
+
+    Answers "how much of my week is meetings?", "who am I spending my time
+    with?" and "where did my focus time go?" in one pass. Working hours, lunch,
+    buffer and the minimum focus block come from the saved preferences
+    (see get_preferences), so the percentages reflect this user's actual day.
+
+    Declined meetings, events marked 'free', and all-day entries are excluded by
+    default; the 'excluded' field says how many were skipped.
+
+    Args:
+        time_min: Start of the window to audit, ISO 8601.
+        time_max: End of the window to audit, ISO 8601.
+        calendar_ids: Calendars to include. Defaults to ['primary'].
+        group_by: Break the window down by 'day' or by ISO 'week'.
+        include_all_day: Count all-day events as meeting time.
+        include_declined: Count meetings the user declined.
+        account: Account name from 'calendar-mcp accounts'; omit for the default.
+    """
+    provider = srv._provider(ctx)
+    calendars = [str(item) for item in (calendar_ids or []) if str(item).strip()] or ["primary"]
+
+    def work() -> TimeAuditResult:
+        creds = provider.get(account)
+        primary = calendars[0]
+        start = srv._require(srv.parse_datetime(time_min, "time_min", creds, primary), "time_min")
+        end = srv._require(srv.parse_datetime(time_max, "time_max", creds, primary), "time_max")
+        if end <= start:
+            raise srv.CalendarToolError("time_max must be after time_min.")
+
+        prefs = preferences_module.load()
+        tzinfo = prefs.tzinfo(srv._default_tzinfo(creds, primary))
+
+        events: List[audit_logic.AuditEvent] = []
+        unreadable: List[str] = []
+        for calendar_id in calendars:
+            response = srv.calendar_actions.find_events(
+                credentials=creds,
+                calendar_id=calendar_id,
+                time_min=start,
+                time_max=end,
+                max_results=MAX_EVENTS_PER_CALENDAR,
+                single_events=True,
+                order_by="startTime",
+            )
+            if response is None:
+                unreadable.append(calendar_id)
+                continue
+            for raw in getattr(response, "items", None) or []:
+                normalised = audit_logic.event_from_google(raw, tzinfo, calendar_id=calendar_id)
+                if normalised is not None:
+                    events.append(normalised)
+
+        if unreadable and len(unreadable) == len(calendars):
+            raise srv._no_result("Auditing time")
+
+        result = audit_logic.build_audit(
+            events,
+            (start, end),
+            prefs,
+            tzinfo,
+            group_by=group_by,
+            calendar_ids=calendars,
+            include_all_day=include_all_day,
+            include_declined=include_declined,
+        )
+        result.calendar_ids = [c for c in calendars if c not in unreadable]
+        return result
+
+    result = await srv._run(work)
+    skipped = [c for c in calendars if c not in result.calendar_ids]
+    if skipped:
+        await srv._warn(ctx, f"No events could be read for: {', '.join(skipped)}.")
+    return result

--- a/calendar_mcp/tools/calendars.py
+++ b/calendar_mcp/tools/calendars.py
@@ -1,0 +1,71 @@
+"""Tools for discovering and creating calendars."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from calendar_mcp import server as srv
+from calendar_mcp.models import CalendarInfo, CalendarListResult
+
+
+@srv.server.tool(
+    name="list_calendars",
+    title="List calendars",
+    annotations=srv.READ_ONLY,
+)
+async def list_calendars(
+    min_access_role: Optional[str] = None,
+    account: Optional[str] = None,
+    ctx: Optional[srv.Context] = None,
+) -> CalendarListResult:
+    """List the calendars the signed-in user can see, with their IDs and timezones.
+
+    Start here whenever the user mentions a calendar other than their own: the
+    `id` values returned are what every other tool's `calendar_id` expects.
+
+    Args:
+        min_access_role: Only return calendars where the user has at least this
+            role: 'freeBusyReader', 'reader', 'writer' or 'owner'. Omit for all.
+        account: Account name from 'calendar-mcp accounts'; omit for the default.
+    """
+    provider = srv._provider(ctx)
+
+    def work() -> CalendarListResult:
+        creds = provider.get(account)
+        response = srv.calendar_actions.find_calendars(creds, min_access_role=min_access_role)
+        if response is None:
+            raise srv._no_result("Listing calendars")
+        calendars = [CalendarInfo.from_entry(entry) for entry in response.items]
+        return CalendarListResult(count=len(calendars), calendars=calendars)
+
+    return await srv._run(work)
+
+
+@srv.server.tool(
+    name="create_calendar",
+    title="Create a calendar",
+    annotations=srv.WRITE,
+)
+async def create_calendar(
+    summary: str,
+    account: Optional[str] = None,
+    ctx: Optional[srv.Context] = None,
+) -> CalendarInfo:
+    """Create a new secondary calendar owned by the user.
+
+    Args:
+        summary: Name for the new calendar, e.g. 'Client work'.
+        account: Account name from 'calendar-mcp accounts'; omit for the default.
+    """
+    provider = srv._provider(ctx)
+
+    def work() -> CalendarInfo:
+        creds = provider.get(account)
+        created = srv.calendar_actions.create_calendar(creds, summary=summary)
+        if created is None:
+            raise srv._no_result("Creating the calendar")
+        # Drop any cached timezone under this brand-new ID.
+        srv._forget_calendar_timezone(created.id)
+        return CalendarInfo.from_entry(created)
+
+    return await srv._run(work)

--- a/calendar_mcp/tools/conflicts.py
+++ b/calendar_mcp/tools/conflicts.py
@@ -1,0 +1,469 @@
+"""Tools that find what is wrong with a schedule, and what to do about it.
+
+``detect_conflicts`` reads events across every signed-in account and reports
+double-bookings, plus the transitions that are technically legal but leave less
+room than the user's buffer asks for. ``suggest_reschedule`` takes one event and
+proposes better times for it, ranked, without moving anything unless asked.
+
+Both lean on :mod:`calendar_mcp.scheduling` for the actual reasoning and on
+:mod:`calendar_mcp.tools.focus` for the two Google-facing helpers they share
+with the focus tools.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, time as dt_time, timedelta
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from googleapiclient.errors import HttpError
+
+from calendar_mcp import accounts as accounts_module
+from calendar_mcp import preferences as preferences_module
+from calendar_mcp import scheduling as scheduling_logic
+from calendar_mcp import server as srv
+from calendar_mcp.models import (
+    ConflictEventRef,
+    ConflictsResult,
+    EventConflict,
+    EventInfo,
+    RescheduleSuggestion,
+    RescheduleSuggestions,
+    TightTransition,
+)
+from calendar_mcp.timeutil import Interval
+from calendar_mcp.tools.focus import selected_calendar_ids, zone_for
+
+#: Events read per calendar before the report warns that it may be incomplete.
+DEFAULT_MAX_EVENTS = 250
+#: Most conflicting (or tight) pairs listed; the counts stay honest either way.
+MAX_PAIRS = 100
+#: Grid the reschedule suggestions are placed on.
+SLOT_STEP_MINUTES = 15
+#: Ceiling on candidate slots, so a wide window cannot blow up the search.
+MAX_CANDIDATE_SLOTS = 2000
+
+_MIDNIGHT = dt_time(0, 0)
+
+
+# ---------------------------------------------------------------------------
+# Event filtering
+# ---------------------------------------------------------------------------
+
+
+def _is_declined(event) -> bool:
+    """True when the signed-in user has declined this invitation."""
+    for attendee in event.attendees or []:
+        if getattr(attendee, "self", False) and (attendee.responseStatus or "") == "declined":
+            return True
+    return False
+
+
+def _is_transparent(event) -> bool:
+    """True when the event is marked 'free' rather than 'busy'.
+
+    Reads :attr:`~calendar_mcp.models.GoogleCalendarEvent.transparency`, which
+    Google sets to ``'transparent'`` for an event the user marked "free"; the
+    ``getattr`` keeps this working against a stub event that omits the field.
+    """
+    return str(getattr(event, "transparency", "") or "").lower() == "transparent"
+
+
+def _event_span(event, zone, include_all_day: bool) -> Optional[Tuple[Interval, bool]]:
+    """The interval an event occupies, or ``None`` when it should be ignored.
+
+    Cancelled events, events the user declined, events marked free, and (unless
+    asked for) all-day events do not clash with anything.
+    """
+    if (event.status or "") == "cancelled":
+        return None
+    if _is_declined(event) or _is_transparent(event):
+        return None
+    start, end = event.start, event.end
+    if start is None or end is None:
+        return None
+    if start.dateTime and end.dateTime:
+        return (start.dateTime, end.dateTime), False
+    if not include_all_day:
+        return None
+    if start.date and end.date:
+        return (srv.combine(start.date, _MIDNIGHT, zone), srv.combine(end.date, _MIDNIGHT, zone)), True
+    return None
+
+
+def _ref(event, account: str, calendar_id: str, span: Interval, all_day: bool, zone) -> ConflictEventRef:
+    return ConflictEventRef(
+        account=account,
+        calendar_id=calendar_id,
+        event_id=event.id,
+        summary=event.summary,
+        start=span[0].astimezone(zone).isoformat(),
+        end=span[1].astimezone(zone).isoformat(),
+        all_day=all_day,
+    )
+
+
+def _account_names(requested: Optional[Sequence[str]]) -> List[str]:
+    """The accounts to read: the ones asked for, else every signed-in one."""
+    if requested:
+        return [accounts_module.validate_account_name(str(name)) for name in requested]
+    known = [info.name for info in accounts_module.list_accounts() if info.valid]
+    return known or [accounts_module.resolve_account(None)]
+
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
+
+
+@srv.server.tool(
+    name="detect_conflicts",
+    title="Detect calendar conflicts",
+    annotations=srv.READ_ONLY,
+)
+async def detect_conflicts(
+    time_min: str,
+    time_max: str,
+    accounts: Optional[List[str]] = None,
+    calendar_ids: Optional[List[str]] = None,
+    include_all_day: bool = False,
+    max_events_per_calendar: int = DEFAULT_MAX_EVENTS,
+    ctx: Optional[srv.Context] = None,
+) -> ConflictsResult:
+    """Find double-booked events in a window, across every signed-in account.
+
+    Reports two things. `conflicts` are genuine overlaps -- the user cannot be
+    in both places. `tight` transitions do not overlap but leave less than the
+    buffer from `get_preferences`, which is what makes a day feel impossible.
+
+    Events the user declined, events marked free, cancelled events and (unless
+    `include_all_day` is set) all-day events are ignored, because none of them
+    actually occupy the user.
+
+    Args:
+        time_min: Start of the window to check, ISO 8601.
+        time_max: End of the window to check, ISO 8601.
+        accounts: Account names to check. Omit for every signed-in account,
+            which is the point of the tool -- a work meeting clashing with a
+            personal one is invisible from either calendar alone.
+        calendar_ids: Restrict to these calendars (in every account checked).
+            Omit for each account's selected calendars.
+        include_all_day: True to let all-day events clash with timed ones.
+        max_events_per_calendar: Safety limit per calendar. Default 250.
+    """
+    provider = srv._provider(ctx)
+    skipped: List[str] = []
+
+    def work() -> ConflictsResult:
+        prefs = preferences_module.load()
+        names = _account_names(accounts)
+
+        refs: List[ConflictEventRef] = []
+        spans: List[Interval] = []
+        read_calendars: List[str] = []
+        zone = None
+        window: Optional[Interval] = None
+
+        for name in names:
+            try:
+                creds = provider.get(name)
+            except srv.AuthError as exc:
+                skipped.append(f"{name}: {exc}")
+                continue
+
+            if window is None:
+                start = srv._require(
+                    srv.parse_datetime(time_min, "time_min", creds, "primary"), "time_min"
+                )
+                end = srv._require(
+                    srv.parse_datetime(time_max, "time_max", creds, "primary"), "time_max"
+                )
+                if end <= start:
+                    raise srv.CalendarToolError("time_max must be after time_min.")
+                window = (start, end)
+                zone = zone_for(prefs, creds)
+
+            ids = (
+                [str(item) for item in calendar_ids]
+                if calendar_ids
+                else selected_calendar_ids(creds)
+            )
+            for calendar_id in ids:
+                try:
+                    response = srv.calendar_actions.find_events(
+                        credentials=creds,
+                        calendar_id=calendar_id,
+                        time_min=window[0],
+                        time_max=window[1],
+                        max_results=max_events_per_calendar,
+                    )
+                except HttpError as exc:
+                    skipped.append(f"{name}:{calendar_id}: {srv._http_error_message(exc)}")
+                    continue
+                if response is None:
+                    skipped.append(f"{name}:{calendar_id}: no result")
+                    continue
+                read_calendars.append(f"{name}:{calendar_id}")
+                if len(response.items) >= max_events_per_calendar:
+                    skipped.append(
+                        f"{name}:{calendar_id}: only the first {max_events_per_calendar} "
+                        "events were read, so later conflicts may be missing"
+                    )
+                for event in response.items:
+                    found = _event_span(event, zone, include_all_day)
+                    if found is None:
+                        continue
+                    span, all_day = found
+                    refs.append(_ref(event, name, calendar_id, span, all_day, zone))
+                    spans.append(span)
+
+        if window is None:
+            raise srv.CalendarToolError(
+                "No account could be read. " + (" ".join(skipped) or "Run 'calendar-mcp auth'.")
+            )
+
+        overlaps = scheduling_logic.overlapping_pairs(spans)
+        tights = scheduling_logic.tight_pairs(spans, prefs.buffer_minutes)
+
+        conflicts = [
+            EventConflict(
+                overlap_minutes=round(minutes, 1),
+                same_calendar=refs[first].calendar_id == refs[second].calendar_id
+                and refs[first].account == refs[second].account,
+                same_account=refs[first].account == refs[second].account,
+                first=refs[first],
+                second=refs[second],
+            )
+            for first, second, minutes in overlaps[:MAX_PAIRS]
+        ]
+        tight = [
+            TightTransition(
+                gap_minutes=round(minutes, 1),
+                buffer_minutes=prefs.buffer_minutes,
+                first=refs[first],
+                second=refs[second],
+            )
+            for first, second, minutes in tights[:MAX_PAIRS]
+        ]
+
+        if overlaps:
+            message = (
+                f"{len(overlaps)} conflict(s) across {len(refs)} events on "
+                f"{len(read_calendars)} calendar(s)."
+            )
+        else:
+            message = f"No conflicts among {len(refs)} events on {len(read_calendars)} calendar(s)."
+        if tights:
+            message += f" {len(tights)} transition(s) leave less than {prefs.buffer_minutes} minutes."
+        if len(overlaps) > MAX_PAIRS or len(tights) > MAX_PAIRS:
+            message += f" Only the first {MAX_PAIRS} of each are listed."
+        if skipped:
+            message += f" {len(skipped)} calendar(s) could not be read in full."
+
+        return ConflictsResult(
+            time_min=window[0].astimezone(zone).isoformat(),
+            time_max=window[1].astimezone(zone).isoformat(),
+            timezone=str(zone),
+            accounts=names,
+            calendar_ids=read_calendars,
+            event_count=len(refs),
+            buffer_minutes=prefs.buffer_minutes,
+            include_all_day=include_all_day,
+            conflict_count=len(overlaps),
+            conflicts=conflicts,
+            tight_count=len(tights),
+            tight=tight,
+            skipped=skipped,
+            message=message,
+        )
+
+    result = await srv._run(work)
+    if result.skipped:
+        await srv._warn(ctx, "Not everything could be read: " + "; ".join(result.skipped))
+    return result
+
+
+@srv.server.tool(
+    name="suggest_reschedule",
+    title="Suggest better times for an event",
+    annotations=srv.UPDATE,
+)
+async def suggest_reschedule(
+    event_id: str,
+    calendar_id: str = "primary",
+    search_days: int = 7,
+    max_suggestions: int = 5,
+    search_from: Optional[str] = None,
+    apply: bool = False,
+    account: Optional[str] = None,
+    ctx: Optional[srv.Context] = None,
+) -> RescheduleSuggestions:
+    """Propose better times for an existing meeting, ranked, keeping its length.
+
+    Reads the event, then looks for slots of the same duration inside the user's
+    working hours where the organiser is free, and ranks them: fewest attendee
+    conflicts first, the event's current day next, then earliest. Slots that sit
+    closer to another meeting than the user's buffer allows are penalised, not
+    hidden.
+
+    Read-only by default -- it suggests, the user decides. Set `apply` to move
+    the event to the top suggestion once they have agreed to it.
+
+    Args:
+        event_id: The event to reschedule (from `find_events`).
+        calendar_id: Calendar the event lives on.
+        search_days: How many days ahead to search. Default 7, maximum 60.
+        max_suggestions: How many times to propose. Default 5, maximum 20.
+        search_from: Start searching from this time, ISO 8601. Defaults to now.
+        apply: True to actually move the event to the best suggestion. Only set
+            this when the user has agreed to the time.
+        account: Account name from 'calendar-mcp accounts'; omit for the default.
+    """
+    provider = srv._provider(ctx)
+
+    def work() -> RescheduleSuggestions:
+        if not event_id:
+            raise srv.CalendarToolError("event_id is required.")
+        if not 1 <= search_days <= 60:
+            raise srv.CalendarToolError("search_days must be between 1 and 60.")
+        if not 1 <= max_suggestions <= 20:
+            raise srv.CalendarToolError("max_suggestions must be between 1 and 20.")
+
+        creds = provider.get(account)
+        prefs = preferences_module.load()
+        zone = zone_for(prefs, creds, calendar_id)
+
+        event = srv.calendar_actions.get_event(
+            credentials=creds, event_id=event_id, calendar_id=calendar_id
+        )
+        if event is None:
+            raise srv._no_result("Reading the event")
+        if not (event.start and event.start.dateTime and event.end and event.end.dateTime):
+            raise srv.CalendarToolError(
+                "suggest_reschedule needs a timed event; this one is all-day, so there is "
+                "no duration to preserve."
+            )
+        original_start = event.start.dateTime
+        original_end = event.end.dateTime
+        duration = scheduling_logic.interval_minutes((original_start, original_end))
+        if duration <= 0:
+            raise srv.CalendarToolError("The event has no duration, so there is nothing to place.")
+
+        attendees = sorted(
+            {
+                str(attendee.email)
+                for attendee in event.attendees or []
+                if attendee.email
+                and not attendee.resource
+                and not getattr(attendee, "self", False)
+                and (attendee.responseStatus or "") != "declined"
+            }
+        )
+
+        search_min = srv.parse_datetime(search_from, "search_from", creds, calendar_id)
+        if search_min is None:
+            search_min = datetime.now(zone)
+        search_min = scheduling_logic.align_up(search_min, SLOT_STEP_MINUTES)
+        search_max = search_min + timedelta(days=search_days)
+
+        busy_by_key: Dict[str, List[Interval]] = {}
+        organizer_busy: List[Interval] = []
+        raw = srv.calendar_actions.find_availability(
+            credentials=creds,
+            time_min=search_min,
+            time_max=search_max,
+            calendar_ids=[calendar_id] + attendees,
+        )
+        if raw is None:
+            raise srv._no_result("Reading free/busy")
+        for key, data in raw.items():
+            intervals = [(item["start"], item["end"]) for item in data.get("busy", [])]
+            if key == calendar_id:
+                organizer_busy = intervals
+            else:
+                busy_by_key[key] = intervals
+
+        windows = preferences_module.working_windows(prefs, search_min, search_max, zone)
+        candidates = scheduling_logic.generate_slots(
+            windows,
+            duration_minutes=int(round(duration)),
+            step_minutes=SLOT_STEP_MINUTES,
+            limit=MAX_CANDIDATE_SLOTS,
+        )
+        ranked = scheduling_logic.rank_slots(
+            candidates,
+            busy_by_key=busy_by_key,
+            unavailable=organizer_busy,
+            original_start=original_start,
+            buffer_minutes=prefs.buffer_minutes,
+            tzinfo=zone,
+            limit=max_suggestions,
+        )
+
+        suggestions = [
+            RescheduleSuggestion(
+                start=slot.start.astimezone(zone).isoformat(),
+                end=slot.end.astimezone(zone).isoformat(),
+                score=slot.score,
+                attendee_conflicts=list(slot.conflicts),
+                reasons=list(slot.reasons),
+            )
+            for slot in ranked
+        ]
+
+        applied = False
+        applied_event: Optional[EventInfo] = None
+        if apply:
+            if not ranked:
+                raise srv.CalendarToolError(
+                    "There is no free slot to move this event to in the next "
+                    f"{search_days} day(s), so nothing was moved. Widen search_days."
+                )
+            best = ranked[0]
+            moved = srv.calendar_actions.move_event(
+                credentials=creds,
+                event_id=event_id,
+                calendar_id=calendar_id,
+                new_start=best.start,
+                new_end=best.end,
+                send_notifications=True,
+            )
+            if moved is None:
+                raise srv._no_result("Moving the event")
+            applied = True
+            applied_event = EventInfo.from_event(moved)
+
+        if not suggestions:
+            message = (
+                f"No free {duration:g}-minute slot inside the working hours in the next "
+                f"{search_days} day(s). Widen search_days or adjust the working hours."
+            )
+        elif applied:
+            message = (
+                f"Moved '{event.summary or event_id}' to {suggestions[0].start} "
+                f"(score {suggestions[0].score:g})."
+            )
+        else:
+            message = (
+                f"{len(suggestions)} suggestion(s) for '{event.summary or event_id}', best first. "
+                "Nothing has been moved."
+            )
+
+        return RescheduleSuggestions(
+            calendar_id=calendar_id,
+            event_id=event_id,
+            summary=event.summary,
+            current_start=original_start.astimezone(zone).isoformat(),
+            current_end=original_end.astimezone(zone).isoformat(),
+            duration_minutes=round(duration, 1),
+            timezone=str(zone),
+            attendees=attendees,
+            search_time_min=search_min.astimezone(zone).isoformat(),
+            search_time_max=search_max.astimezone(zone).isoformat(),
+            count=len(suggestions),
+            suggestions=suggestions,
+            applied=applied,
+            applied_event=applied_event,
+            message=message,
+        )
+
+    return await srv._run(work)

--- a/calendar_mcp/tools/events.py
+++ b/calendar_mcp/tools/events.py
@@ -1,0 +1,576 @@
+"""Tools that read and write individual calendar events."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from calendar_mcp import server as srv
+from calendar_mcp.models import (
+    AttendeeStatusEntry,
+    AttendeeStatusResult,
+    DeleteEventResult,
+    EventCreateRequest,
+    EventDateTime,
+    EventInfo,
+    EventListResult,
+    EventResult,
+    EventUpdateRequest,
+)
+
+
+# ---------------------------------------------------------------------------
+# Reading
+# ---------------------------------------------------------------------------
+
+
+@srv.server.tool(
+    name="find_events",
+    title="Find events",
+    annotations=srv.READ_ONLY,
+)
+async def find_events(
+    calendar_id: str = "primary",
+    time_min: Optional[str] = None,
+    time_max: Optional[str] = None,
+    query: Optional[str] = None,
+    max_results: int = 50,
+    account: Optional[str] = None,
+    ctx: Optional[srv.Context] = None,
+) -> EventListResult:
+    """Search a calendar for events, expanding recurring series into instances.
+
+    Use this before any tool that needs an `event_id`. Narrow the window with
+    `time_min`/`time_max` rather than raising `max_results`.
+
+    Args:
+        calendar_id: Calendar to search. 'primary' is the user's own calendar.
+        time_min: Inclusive start of the window, ISO 8601 with a UTC offset.
+            Without an offset it is read in the calendar's own timezone.
+        time_max: Exclusive end of the window, ISO 8601.
+        query: Free-text search over title, description, location and attendees.
+        max_results: Maximum events to return (default 50).
+        account: Account name from 'calendar-mcp accounts'; omit for the default.
+    """
+    provider = srv._provider(ctx)
+
+    def work() -> EventListResult:
+        creds = provider.get(account)
+        response = srv.calendar_actions.find_events(
+            credentials=creds,
+            calendar_id=calendar_id,
+            time_min=srv.parse_datetime(time_min, "time_min", creds, calendar_id),
+            time_max=srv.parse_datetime(time_max, "time_max", creds, calendar_id),
+            query=query,
+            max_results=max_results,
+        )
+        if response is None:
+            raise srv._no_result("Finding events")
+        events = [EventInfo.from_event(item) for item in response.items]
+        return EventListResult(
+            calendar_id=calendar_id,
+            count=len(events),
+            events=events,
+            time_zone=response.timeZone,
+        )
+
+    result = await srv._run(work)
+    if result.count >= max_results:
+        await srv._warn(
+            ctx,
+            f"find_events hit the max_results limit of {max_results}; there may be more "
+            "events in this window.",
+        )
+    return result
+
+
+@srv.server.tool(
+    name="check_attendee_status",
+    title="Check attendee RSVPs",
+    annotations=srv.READ_ONLY,
+)
+async def check_attendee_status(
+    event_id: str,
+    calendar_id: str = "primary",
+    attendee_emails: Optional[List[str]] = None,
+    account: Optional[str] = None,
+    ctx: Optional[srv.Context] = None,
+) -> AttendeeStatusResult:
+    """Report who has accepted, declined or not yet answered an event invitation.
+
+    Args:
+        event_id: The event to inspect (from `find_events`).
+        calendar_id: Calendar the event lives on.
+        attendee_emails: Restrict the report to these addresses. Omit for all.
+        account: Account name from 'calendar-mcp accounts'; omit for the default.
+    """
+    provider = srv._provider(ctx)
+
+    def work() -> AttendeeStatusResult:
+        creds = provider.get(account)
+        statuses = srv.calendar_actions.check_attendee_status(
+            credentials=creds,
+            event_id=event_id,
+            calendar_id=calendar_id,
+            attendee_emails=attendee_emails,
+        )
+        if statuses is None:
+            raise srv._no_result("Checking attendee status")
+        entries = [
+            AttendeeStatusEntry(email=str(email), response_status=status)
+            for email, status in statuses.items()
+        ]
+        return AttendeeStatusResult(
+            calendar_id=calendar_id,
+            event_id=event_id,
+            count=len(entries),
+            attendees=entries,
+        )
+
+    return await srv._run(work)
+
+
+# ---------------------------------------------------------------------------
+# Writing
+# ---------------------------------------------------------------------------
+
+
+@srv.server.tool(
+    name="create_event",
+    title="Create an event",
+    annotations=srv.WRITE,
+)
+async def create_event(
+    calendar_id: str = "primary",
+    summary: str = "",
+    start_time: str = "",
+    end_time: str = "",
+    description: Optional[str] = None,
+    location: Optional[str] = None,
+    attendee_emails: Optional[List[str]] = None,
+    send_notifications: bool = True,
+    account: Optional[str] = None,
+    ctx: Optional[srv.Context] = None,
+) -> EventResult:
+    """Create an event with explicit start and end times, and optional attendees.
+
+    For a one-line natural-language description ("coffee with Sam tomorrow at 3")
+    prefer `quick_add_event`.
+
+    Args:
+        calendar_id: Calendar to create the event on.
+        summary: Event title. Required.
+        start_time: Start, ISO 8601 with a UTC offset (e.g. '2026-03-14T15:00:00-04:00').
+            Without an offset it is read in the calendar's own timezone.
+        end_time: End, ISO 8601, same convention as start_time.
+        description: Longer notes for the event body.
+        location: Free-text location or meeting link.
+        attendee_emails: People to invite. They receive an invitation email
+            unless send_notifications is false.
+        send_notifications: Whether Google emails the attendees. Default true.
+        account: Account name from 'calendar-mcp accounts'; omit for the default.
+    """
+    provider = srv._provider(ctx)
+
+    def work() -> EventResult:
+        if not summary:
+            raise srv.CalendarToolError("summary is required.")
+        creds = provider.get(account)
+        start = srv._require(
+            srv.parse_datetime(start_time, "start_time", creds, calendar_id), "start_time"
+        )
+        end = srv._require(
+            srv.parse_datetime(end_time, "end_time", creds, calendar_id), "end_time"
+        )
+        if end <= start:
+            raise srv.CalendarToolError("end_time must be after start_time.")
+        request = EventCreateRequest(
+            summary=summary,
+            start=EventDateTime(dateTime=start),
+            end=EventDateTime(dateTime=end),
+            description=description,
+            location=location,
+            attendees=attendee_emails or None,
+        )
+        created = srv.calendar_actions.create_event(
+            credentials=creds,
+            event_data=request,
+            calendar_id=calendar_id,
+            send_notifications=send_notifications,
+        )
+        if created is None:
+            raise srv._no_result("Creating the event")
+        return EventResult(
+            calendar_id=calendar_id,
+            event=EventInfo.from_event(created),
+            message=f"Created '{created.summary}' starting {start.isoformat()}.",
+        )
+
+    return await srv._run(work)
+
+
+@srv.server.tool(
+    name="quick_add_event",
+    title="Quick-add an event",
+    annotations=srv.WRITE,
+)
+async def quick_add_event(
+    text: str,
+    calendar_id: str = "primary",
+    account: Optional[str] = None,
+    ctx: Optional[srv.Context] = None,
+) -> EventResult:
+    """Create an event from a plain-English phrase, parsed by Google.
+
+    Google interprets the date, time and title itself, in the calendar's own
+    timezone. Check the returned start/end and tell the user what was booked --
+    the parser guesses, and does not handle attendees or descriptions.
+
+    Args:
+        text: The phrase to parse, e.g. 'Dentist Thursday 9am' or
+            'Team sync every Monday at 10 for 30 minutes'.
+        calendar_id: Calendar to create the event on.
+        account: Account name from 'calendar-mcp accounts'; omit for the default.
+    """
+    provider = srv._provider(ctx)
+
+    def work() -> EventResult:
+        if not text.strip():
+            raise srv.CalendarToolError("text is required.")
+        creds = provider.get(account)
+        created = srv.calendar_actions.quick_add_event(
+            credentials=creds,
+            text=text,
+            calendar_id=calendar_id,
+        )
+        if created is None:
+            raise srv._no_result("Quick-adding the event")
+        info = EventInfo.from_event(created)
+        return EventResult(
+            calendar_id=calendar_id,
+            event=info,
+            message=f"Google parsed {text!r} as '{info.summary}' starting {info.start}.",
+        )
+
+    return await srv._run(work)
+
+
+@srv.server.tool(
+    name="update_event",
+    title="Update an event",
+    annotations=srv.UPDATE,
+)
+async def update_event(
+    calendar_id: str = "primary",
+    event_id: str = "",
+    summary: Optional[str] = None,
+    start_time: Optional[str] = None,
+    end_time: Optional[str] = None,
+    description: Optional[str] = None,
+    location: Optional[str] = None,
+    send_notifications: bool = True,
+    account: Optional[str] = None,
+    ctx: Optional[srv.Context] = None,
+) -> EventResult:
+    """Change fields on an existing event. Omitted fields are left untouched.
+
+    To reschedule while keeping the duration, use `move_event` instead: changing
+    only `start_time` here leaves the old end time in place.
+
+    Args:
+        calendar_id: Calendar the event lives on.
+        event_id: The event to update (from `find_events`). Required.
+        summary: New title.
+        start_time: New start, ISO 8601.
+        end_time: New end, ISO 8601.
+        description: New description.
+        location: New location.
+        send_notifications: Whether Google emails the attendees. Default true.
+        account: Account name from 'calendar-mcp accounts'; omit for the default.
+    """
+    provider = srv._provider(ctx)
+
+    def work() -> EventResult:
+        if not event_id:
+            raise srv.CalendarToolError("event_id is required.")
+        creds = provider.get(account)
+        start = srv.parse_datetime(start_time, "start_time", creds, calendar_id)
+        end = srv.parse_datetime(end_time, "end_time", creds, calendar_id)
+        if start and end and end <= start:
+            raise srv.CalendarToolError("end_time must be after start_time.")
+        update = EventUpdateRequest(
+            summary=summary,
+            start=EventDateTime(dateTime=start) if start else None,
+            end=EventDateTime(dateTime=end) if end else None,
+            description=description,
+            location=location,
+        )
+        if not update.model_dump(exclude_none=True):
+            raise srv.CalendarToolError(
+                "Nothing to update: pass at least one of summary, start_time, "
+                "end_time, description or location."
+            )
+        updated = srv.calendar_actions.update_event(
+            credentials=creds,
+            event_id=event_id,
+            update_data=update,
+            calendar_id=calendar_id,
+            send_notifications=send_notifications,
+        )
+        if updated is None:
+            raise srv._no_result("Updating the event")
+        return EventResult(
+            calendar_id=calendar_id,
+            event=EventInfo.from_event(updated),
+            message=f"Updated event {event_id}.",
+        )
+
+    result = await srv._run(work)
+    if start_time and not end_time:
+        await srv._warn(
+            ctx,
+            "update_event changed only the start time; the end time is unchanged. "
+            "Use move_event to shift an event and keep its duration.",
+        )
+    return result
+
+
+@srv.server.tool(
+    name="move_event",
+    title="Move or reschedule an event",
+    annotations=srv.UPDATE,
+)
+async def move_event(
+    event_id: str,
+    calendar_id: str = "primary",
+    new_start: Optional[str] = None,
+    new_end: Optional[str] = None,
+    destination_calendar_id: Optional[str] = None,
+    send_notifications: bool = True,
+    account: Optional[str] = None,
+    ctx: Optional[srv.Context] = None,
+) -> EventResult:
+    """Reschedule an event, and/or move it to a different calendar.
+
+    Supplying only `new_start` keeps the event's original duration -- this is the
+    right tool for "push my 2pm back an hour". Supplying
+    `destination_calendar_id` transfers the event between calendars.
+
+    Args:
+        event_id: The event to move (from `find_events`).
+        calendar_id: Calendar the event currently lives on.
+        new_start: New start, ISO 8601. Duration is preserved if new_end is omitted.
+        new_end: New end, ISO 8601. Optional when new_start is given.
+        destination_calendar_id: Calendar to transfer the event to.
+        send_notifications: Whether Google emails the attendees. Default true.
+        account: Account name from 'calendar-mcp accounts'; omit for the default.
+    """
+    provider = srv._provider(ctx)
+
+    def work() -> EventResult:
+        if not event_id:
+            raise srv.CalendarToolError("event_id is required.")
+        if not new_start and not new_end and not destination_calendar_id:
+            raise srv.CalendarToolError(
+                "Pass at least one of new_start, new_end or destination_calendar_id."
+            )
+        creds = provider.get(account)
+        start = srv.parse_datetime(new_start, "new_start", creds, calendar_id)
+        end = srv.parse_datetime(new_end, "new_end", creds, calendar_id)
+        if start and end and end <= start:
+            raise srv.CalendarToolError("new_end must be after new_start.")
+        moved = srv.calendar_actions.move_event(
+            credentials=creds,
+            event_id=event_id,
+            calendar_id=calendar_id,
+            new_start=start,
+            new_end=end,
+            destination_calendar_id=destination_calendar_id,
+            send_notifications=send_notifications,
+        )
+        if moved is None:
+            raise srv._no_result("Moving the event")
+        info = EventInfo.from_event(moved)
+        where = destination_calendar_id or calendar_id
+        return EventResult(
+            calendar_id=where,
+            event=info,
+            message=f"Event {event_id} now runs {info.start} to {info.end} on '{where}'.",
+        )
+
+    result = await srv._run(work)
+    if new_start and not new_end and result.event.all_day:
+        await srv._warn(
+            ctx,
+            "This is an all-day event, so no duration could be preserved; "
+            "pass new_end explicitly if the length should change.",
+        )
+    return result
+
+
+@srv.server.tool(
+    name="add_attendee",
+    title="Add attendees",
+    annotations=srv.UPDATE,
+)
+async def add_attendee(
+    event_id: str,
+    attendee_emails: List[str],
+    calendar_id: str = "primary",
+    send_notifications: bool = True,
+    account: Optional[str] = None,
+    ctx: Optional[srv.Context] = None,
+) -> EventResult:
+    """Invite one or more people to an existing event.
+
+    Existing attendees are kept; the new addresses are appended.
+
+    Args:
+        event_id: The event to invite people to (from `find_events`).
+        attendee_emails: Email addresses to invite.
+        calendar_id: Calendar the event lives on.
+        send_notifications: Whether Google emails the attendees. Default true.
+        account: Account name from 'calendar-mcp accounts'; omit for the default.
+    """
+    provider = srv._provider(ctx)
+
+    def work() -> EventResult:
+        if not event_id:
+            raise srv.CalendarToolError("event_id is required.")
+        if not attendee_emails:
+            raise srv.CalendarToolError("attendee_emails must contain at least one address.")
+        creds = provider.get(account)
+        updated = srv.calendar_actions.add_attendee(
+            credentials=creds,
+            event_id=event_id,
+            attendee_emails=list(attendee_emails),
+            calendar_id=calendar_id,
+            send_notifications=send_notifications,
+        )
+        if updated is None:
+            raise srv._no_result("Adding attendees")
+        return EventResult(
+            calendar_id=calendar_id,
+            event=EventInfo.from_event(updated),
+            message=f"Invited {', '.join(attendee_emails)} to event {event_id}.",
+        )
+
+    return await srv._run(work)
+
+
+@srv.server.tool(
+    name="respond_to_event",
+    title="RSVP to an event",
+    annotations=srv.UPDATE,
+)
+async def respond_to_event(
+    event_id: str,
+    response_status: str,
+    calendar_id: str = "primary",
+    comment: Optional[str] = None,
+    send_notifications: bool = True,
+    account: Optional[str] = None,
+    ctx: Optional[srv.Context] = None,
+) -> EventResult:
+    """Set the user's own RSVP on an invitation they have received.
+
+    Only works on events the user is an attendee of; it does not change anyone
+    else's response.
+
+    Args:
+        event_id: The invitation to answer (from `find_events`).
+        response_status: 'accepted', 'declined', 'tentative' or 'needsAction'.
+        calendar_id: Calendar the invitation lives on.
+        comment: Optional note sent to the organizer with the RSVP.
+        send_notifications: Whether Google emails the organizer. Default true.
+        account: Account name from 'calendar-mcp accounts'; omit for the default.
+    """
+    provider = srv._provider(ctx)
+
+    def work() -> EventResult:
+        if not event_id:
+            raise srv.CalendarToolError("event_id is required.")
+        creds = provider.get(account)
+        updated = srv.calendar_actions.respond_to_event(
+            credentials=creds,
+            event_id=event_id,
+            response_status=response_status,
+            calendar_id=calendar_id,
+            comment=comment,
+            send_notifications=send_notifications,
+        )
+        if updated is None:
+            raise srv._no_result("Responding to the event")
+        return EventResult(
+            calendar_id=calendar_id,
+            event=EventInfo.from_event(updated),
+            message=f"RSVP for event {event_id} set to '{response_status}'.",
+        )
+
+    return await srv._run(work)
+
+
+# ---------------------------------------------------------------------------
+# Deleting (with optional confirmation)
+# ---------------------------------------------------------------------------
+
+
+@srv.server.tool(
+    name="delete_event",
+    title="Delete an event",
+    annotations=srv.DESTRUCTIVE,
+)
+async def delete_event(
+    event_id: str,
+    calendar_id: str = "primary",
+    send_notifications: bool = True,
+    account: Optional[str] = None,
+    ctx: Optional[srv.Context] = None,
+) -> DeleteEventResult:
+    """Permanently delete an event. This cannot be undone.
+
+    Clients that support elicitation are asked to confirm first; if the user
+    declines, nothing is deleted and `deleted` comes back false.
+
+    Args:
+        event_id: The event to delete (from `find_events`).
+        calendar_id: Calendar the event lives on.
+        send_notifications: Whether Google emails the attendees that it was
+            cancelled. Default true.
+        account: Account name from 'calendar-mcp accounts'; omit for the default.
+    """
+    if not event_id:
+        raise srv.CalendarToolError("event_id is required.")
+
+    confirmed = await srv._confirm_delete(ctx, f"event {event_id} on calendar '{calendar_id}'")
+    if confirmed is False:
+        return DeleteEventResult(
+            calendar_id=calendar_id,
+            event_id=event_id,
+            deleted=False,
+            confirmed_by_user=False,
+            message="Deletion cancelled by the user; nothing was changed.",
+        )
+
+    provider = srv._provider(ctx)
+
+    def work() -> bool:
+        creds = provider.get(account)
+        return bool(
+            srv.calendar_actions.delete_event(
+                credentials=creds,
+                event_id=event_id,
+                calendar_id=calendar_id,
+                send_notifications=send_notifications,
+            )
+        )
+
+    deleted = await srv._run(work)
+    if not deleted:
+        raise srv._no_result("Deleting the event")
+    return DeleteEventResult(
+        calendar_id=calendar_id,
+        event_id=event_id,
+        deleted=True,
+        confirmed_by_user=confirmed,
+        message=f"Deleted event {event_id} from '{calendar_id}'.",
+    )

--- a/calendar_mcp/tools/focus.py
+++ b/calendar_mcp/tools/focus.py
@@ -1,0 +1,399 @@
+"""Tools that find and book uninterrupted time.
+
+``find_focus_time`` answers "when could I actually think this week"; it reads
+the user's working hours, lunch and buffer from
+:mod:`calendar_mcp.preferences`, subtracts everything already on their
+calendars, and reports what is left. ``block_focus_time`` takes the same
+candidates and defends them by putting real events on the calendar.
+
+The reasoning is in :mod:`calendar_mcp.scheduling`, which is pure and unit
+tested; the tools here only fetch, convert and report. Two small Google-facing
+helpers -- :func:`zone_for` and :func:`selected_calendar_ids` -- are shared with
+:mod:`calendar_mcp.tools.conflicts`, which imports them from here.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional, Tuple
+
+from googleapiclient.errors import HttpError
+
+from calendar_mcp import preferences as preferences_module
+from calendar_mcp import scheduling as scheduling_logic
+from calendar_mcp import server as srv
+from calendar_mcp.models import (
+    BlockedFocusEvent,
+    BlockedFocusResult,
+    EventCreateRequest,
+    EventDateTime,
+    EventReminders,
+    FocusBlock,
+    FocusTimeResult,
+)
+from calendar_mcp.timeutil import Interval
+
+#: What a focus block is called when the caller does not say.
+DEFAULT_FOCUS_TITLE = "Focus time"
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers (also used by calendar_mcp.tools.conflicts)
+# ---------------------------------------------------------------------------
+
+
+def zone_for(prefs: "preferences_module.Preferences", creds, calendar_id: str = "primary"):
+    """The timezone to express results in: the user's preference, else the calendar's."""
+    return prefs.tzinfo(None) or srv._default_tzinfo(creds, calendar_id)
+
+
+def selected_calendar_ids(creds) -> List[str]:
+    """Every calendar the user has ticked on, which is what "my calendar" means.
+
+    Hidden, deleted and unselected calendars are skipped -- a calendar the user
+    has switched off in the Google UI should not eat their focus time. Falls
+    back to ``['primary']`` when the list cannot be read or is empty.
+    """
+    response = srv.calendar_actions.find_calendars(creds)
+    if response is None:
+        return ["primary"]
+    chosen = [
+        entry.id
+        for entry in response.items
+        if entry.id and not entry.deleted and not entry.hidden and entry.selected is not False
+    ]
+    return chosen or ["primary"]
+
+
+def _busy_intervals(
+    creds,
+    time_min: datetime,
+    time_max: datetime,
+    calendar_ids: List[str],
+) -> Tuple[List[Interval], List[str]]:
+    """Free/busy across ``calendar_ids``, as intervals plus per-calendar problems."""
+    raw = srv.calendar_actions.find_availability(
+        credentials=creds,
+        time_min=time_min,
+        time_max=time_max,
+        calendar_ids=list(calendar_ids),
+    )
+    if raw is None:
+        raise srv._no_result("Reading free/busy")
+
+    busy: List[Interval] = []
+    problems: List[str] = []
+    for calendar_id, data in raw.items():
+        for error in data.get("errors") or []:
+            reason = error.get("reason", str(error)) if isinstance(error, dict) else str(error)
+            problems.append(f"{calendar_id}: {reason}")
+        for interval in data.get("busy", []):
+            busy.append((interval["start"], interval["end"]))
+    return busy, problems
+
+
+def _to_block(interval: Interval, zone) -> FocusBlock:
+    """Renders one free interval as the FocusBlock the client sees."""
+    start = interval[0].astimezone(zone)
+    end = interval[1].astimezone(zone)
+    return FocusBlock(
+        start=start.isoformat(),
+        end=end.isoformat(),
+        duration_minutes=round(scheduling_logic.interval_minutes(interval), 1),
+        date=start.date().isoformat(),
+        weekday=start.strftime("%A"),
+    )
+
+
+def _find_blocks(
+    creds,
+    prefs: "preferences_module.Preferences",
+    time_min: datetime,
+    time_max: datetime,
+    calendar_ids: List[str],
+    zone,
+) -> Tuple[List[Interval], List[str]]:
+    """The usable focus blocks in the window, plus any unreadable calendars.
+
+    Working hours (minus lunch) come from the preferences, busy time from
+    free/busy across ``calendar_ids``, and the buffer and minimum block length
+    from the preferences again.
+    """
+    busy, problems = _busy_intervals(creds, time_min, time_max, calendar_ids)
+    windows = preferences_module.working_windows(prefs, time_min, time_max, zone)
+    blocks = scheduling_logic.candidate_blocks(
+        windows,
+        busy,
+        min_block_minutes=prefs.min_focus_block_minutes,
+        buffer_minutes=prefs.buffer_minutes,
+    )
+    return blocks, problems
+
+
+def _validate_window(start: datetime, end: datetime, hours_needed: float) -> None:
+    if end <= start:
+        raise srv.CalendarToolError("time_max must be after time_min.")
+    if hours_needed < 0:
+        raise srv.CalendarToolError("hours_needed cannot be negative.")
+
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
+
+
+@srv.server.tool(
+    name="find_focus_time",
+    title="Find focus time",
+    annotations=srv.READ_ONLY,
+)
+async def find_focus_time(
+    time_min: str,
+    time_max: str,
+    hours_needed: float,
+    calendar_ids: Optional[List[str]] = None,
+    account: Optional[str] = None,
+    ctx: Optional[srv.Context] = None,
+) -> FocusTimeResult:
+    """Find the uninterrupted blocks in a window that could be used for deep work.
+
+    Searches inside the user's working hours (`get_preferences`), removes lunch,
+    everything already booked on their calendars, and the buffer they like
+    around meetings, then reports what is left -- longest block first, because
+    that is the one worth protecting. Blocks shorter than
+    `min_focus_block_minutes` are not reported at all.
+
+    Read-only: use `block_focus_time` to actually defend the time.
+
+    Args:
+        time_min: Start of the window to search, ISO 8601. Without a UTC offset
+            it is read in the calendar's own timezone.
+        time_max: End of the window to search, ISO 8601.
+        hours_needed: How many focus hours the user is trying to find. Used to
+            report whether the window can supply them; pass 0 to just look.
+        calendar_ids: Calendars whose events count as busy. Omit for every
+            calendar the account has selected.
+        account: Account name from 'calendar-mcp accounts'; omit for the default.
+    """
+    provider = srv._provider(ctx)
+    problems: List[str] = []
+
+    def work() -> FocusTimeResult:
+        creds = provider.get(account)
+        prefs = preferences_module.load()
+        start = srv._require(srv.parse_datetime(time_min, "time_min", creds, "primary"), "time_min")
+        end = srv._require(srv.parse_datetime(time_max, "time_max", creds, "primary"), "time_max")
+        _validate_window(start, end, hours_needed)
+
+        zone = zone_for(prefs, creds)
+        ids = [str(item) for item in calendar_ids] if calendar_ids else selected_calendar_ids(creds)
+        blocks, issues = _find_blocks(creds, prefs, start, end, ids, zone)
+        problems.extend(issues)
+
+        available = scheduling_logic.total_hours(blocks)
+        satisfiable = available + 1e-9 >= hours_needed
+        ranked = scheduling_logic.rank_blocks(blocks)
+
+        if not ranked:
+            message = (
+                f"No free block of at least {prefs.min_focus_block_minutes} minutes exists "
+                "inside the working hours in that window."
+            )
+        elif satisfiable:
+            message = (
+                f"{available:g} focus hours available in {len(ranked)} block(s); "
+                f"{hours_needed:g} requested."
+            )
+        else:
+            message = (
+                f"Only {available:g} of the {hours_needed:g} focus hours requested are "
+                f"available, in {len(ranked)} block(s). Widen the window or shorten the ask."
+            )
+
+        return FocusTimeResult(
+            time_min=start.astimezone(zone).isoformat(),
+            time_max=end.astimezone(zone).isoformat(),
+            timezone=str(zone),
+            calendar_ids=ids,
+            hours_needed=float(hours_needed),
+            total_free_hours=available,
+            satisfiable=satisfiable,
+            min_block_minutes=prefs.min_focus_block_minutes,
+            buffer_minutes=prefs.buffer_minutes,
+            count=len(ranked),
+            blocks=[_to_block(block, zone) for block in ranked],
+            message=message,
+        )
+
+    result = await srv._run(work)
+    if problems:
+        await srv._warn(
+            ctx,
+            "Free/busy could not be read for: " + "; ".join(problems)
+            + ". Those calendars were treated as free.",
+        )
+    return result
+
+
+@srv.server.tool(
+    name="block_focus_time",
+    title="Book focus time",
+    annotations=srv.WRITE,
+)
+async def block_focus_time(
+    time_min: str,
+    time_max: str,
+    hours_needed: float,
+    title: str = DEFAULT_FOCUS_TITLE,
+    calendar_id: Optional[str] = None,
+    check_calendar_ids: Optional[List[str]] = None,
+    description: Optional[str] = None,
+    dry_run: bool = False,
+    account: Optional[str] = None,
+    ctx: Optional[srv.Context] = None,
+) -> BlockedFocusResult:
+    """Book the best free blocks in a window as focus time, until the hours add up.
+
+    Takes the blocks `find_focus_time` would report, longest first, and creates
+    an event on each until `hours_needed` is covered. The last block is trimmed
+    to what is still needed rather than swallowing a whole afternoon. Events are
+    created busy, with reminders off and without notifying anyone.
+
+    Run it with `dry_run` first when the user has not yet agreed to the times.
+
+    Args:
+        time_min: Start of the window to book inside, ISO 8601.
+        time_max: End of the window, ISO 8601.
+        hours_needed: How many focus hours to book.
+        title: Title for the blocks. Default 'Focus time'.
+        calendar_id: Calendar to book on. Omit for the user's configured
+            focus_calendar_id (see `get_preferences`).
+        check_calendar_ids: Calendars whose events count as busy. Omit for every
+            calendar the account has selected.
+        description: Optional note to put in each block.
+        dry_run: True to report the blocks that would be booked without writing
+            anything to the calendar.
+        account: Account name from 'calendar-mcp accounts'; omit for the default.
+    """
+    provider = srv._provider(ctx)
+    problems: List[str] = []
+
+    def work() -> BlockedFocusResult:
+        creds = provider.get(account)
+        prefs = preferences_module.load()
+        target = (calendar_id or prefs.focus_calendar_id or "primary").strip()
+        start = srv._require(srv.parse_datetime(time_min, "time_min", creds, target), "time_min")
+        end = srv._require(srv.parse_datetime(time_max, "time_max", creds, target), "time_max")
+        _validate_window(start, end, hours_needed)
+        if hours_needed <= 0:
+            raise srv.CalendarToolError(
+                "hours_needed must be greater than zero; use find_focus_time to just look."
+            )
+
+        zone = zone_for(prefs, creds, target)
+        ids = (
+            [str(item) for item in check_calendar_ids]
+            if check_calendar_ids
+            else selected_calendar_ids(creds)
+        )
+        blocks, issues = _find_blocks(creds, prefs, start, end, ids, zone)
+        problems.extend(issues)
+
+        available = scheduling_logic.total_hours(blocks)
+        chosen = scheduling_logic.select_blocks(
+            blocks, hours_needed, min_block_minutes=prefs.min_focus_block_minutes
+        )
+        if not chosen:
+            raise srv.CalendarToolError(
+                f"No free block of at least {prefs.min_focus_block_minutes} minutes exists "
+                f"inside the working hours between {start.astimezone(zone).isoformat()} and "
+                f"{end.astimezone(zone).isoformat()}. Widen the window, or lower "
+                "min_focus_block_minutes with set_preferences."
+            )
+
+        booked: List[BlockedFocusEvent] = []
+        failure: Optional[str] = None
+        for block_start, block_end in chosen:
+            local_start = block_start.astimezone(zone)
+            local_end = block_end.astimezone(zone)
+            entry = BlockedFocusEvent(
+                start=local_start.isoformat(),
+                end=local_end.isoformat(),
+                duration_minutes=round(scheduling_logic.interval_minutes((block_start, block_end)), 1),
+                summary=title,
+                created=False,
+            )
+            if dry_run:
+                booked.append(entry)
+                continue
+            details = EventCreateRequest(
+                summary=title,
+                start=EventDateTime(dateTime=local_start),
+                end=EventDateTime(dateTime=local_end),
+                description=description,
+                # A promise to yourself, not a meeting: no reminder, no email.
+                reminders=EventReminders(useDefault=False, overrides=[]),
+            )
+            try:
+                created = srv.calendar_actions.create_event(
+                    credentials=creds,
+                    event_data=details,
+                    calendar_id=target,
+                    send_notifications=False,
+                )
+            except HttpError as exc:
+                # Stop, but still report the blocks that did get booked -- a
+                # half-applied write the caller cannot see is far worse.
+                failure = srv._http_error_message(exc)
+                break
+            if created is None:
+                failure = "Google did not return the created event."
+                break
+            entry = entry.model_copy(
+                update={
+                    "created": True,
+                    "event_id": created.id,
+                    "html_link": created.html_link,
+                }
+            )
+            booked.append(entry)
+
+        hours_booked = scheduling_logic.total_hours(
+            [(block_start, block_end) for block_start, block_end in chosen[: len(booked)]]
+        )
+        satisfied = hours_booked + 1e-9 >= hours_needed
+        verb = "Would book" if dry_run else "Booked"
+        message = (
+            f"{verb} {hours_booked:g} of the {hours_needed:g} focus hours requested "
+            f"in {len(booked)} block(s) on '{target}'."
+        )
+        if failure:
+            message += f" Stopped early: {failure}"
+        elif not satisfied:
+            message += " The window did not have enough free time for the rest."
+
+        return BlockedFocusResult(
+            calendar_id=target,
+            time_min=start.astimezone(zone).isoformat(),
+            time_max=end.astimezone(zone).isoformat(),
+            timezone=str(zone),
+            dry_run=dry_run,
+            hours_needed=float(hours_needed),
+            hours_booked=hours_booked,
+            total_free_hours=available,
+            satisfied=satisfied,
+            count=len(booked),
+            events=booked,
+            message=message,
+        )
+
+    result = await srv._run(work)
+    if problems:
+        await srv._warn(
+            ctx,
+            "Free/busy could not be read for: " + "; ".join(problems)
+            + ". Those calendars were treated as free.",
+        )
+    if not result.dry_run and not result.satisfied:
+        await srv._warn(ctx, result.message)
+    return result

--- a/calendar_mcp/tools/scheduling.py
+++ b/calendar_mcp/tools/scheduling.py
@@ -1,0 +1,377 @@
+"""Tools that reason about availability across calendars.
+
+The interval maths these build on lives in :mod:`calendar_mcp.timeutil`
+(``free_windows``, ``merge_intervals``, ``subtract_intervals``), the ranking and
+block-finding in :mod:`calendar_mcp.scheduling`, and the user's own constraints
+in :mod:`calendar_mcp.preferences` (``working_windows``), so a new scheduling
+tool should not have to reimplement any of them.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, time as dt_time, timedelta
+from typing import List, Optional, Tuple
+
+from calendar_mcp import preferences as preferences_module
+from calendar_mcp import scheduling as scheduling_logic
+from calendar_mcp import server as srv
+from calendar_mcp.models import (
+    BusyPeriod,
+    CalendarBusyPeriods,
+    EventCreateRequest,
+    EventDateTime,
+    EventInfo,
+    EventResult,
+    FreeBusyResult,
+)
+from calendar_mcp.timeutil import Interval, clip_intervals, combine, iter_days, parse_clock
+
+
+@srv.server.tool(
+    name="query_free_busy",
+    title="Query free/busy",
+    annotations=srv.READ_ONLY,
+)
+async def query_free_busy(
+    calendar_ids: List[str],
+    time_min: str,
+    time_max: str,
+    account: Optional[str] = None,
+    ctx: Optional[srv.Context] = None,
+) -> FreeBusyResult:
+    """Get busy intervals for one or more calendars, without revealing event details.
+
+    Works for other people's calendars addressed by email, which is how you check
+    whether someone is free before proposing a time.
+
+    Args:
+        calendar_ids: Calendar IDs or attendee email addresses to check.
+        time_min: Start of the window, ISO 8601 with a UTC offset.
+        time_max: End of the window, ISO 8601 with a UTC offset.
+        account: Account name from 'calendar-mcp accounts'; omit for the default.
+    """
+    provider = srv._provider(ctx)
+
+    def work() -> FreeBusyResult:
+        creds = provider.get(account)
+        start = srv._require(
+            srv.parse_datetime(time_min, "time_min", creds, "primary"), "time_min"
+        )
+        end = srv._require(srv.parse_datetime(time_max, "time_max", creds, "primary"), "time_max")
+        raw = srv.calendar_actions.find_availability(
+            credentials=creds,
+            time_min=start,
+            time_max=end,
+            calendar_ids=list(calendar_ids),
+        )
+        if raw is None:
+            raise srv._no_result("Querying free/busy")
+        calendars = []
+        for cal_id, data in raw.items():
+            calendars.append(
+                CalendarBusyPeriods(
+                    calendar_id=cal_id,
+                    busy=[
+                        BusyPeriod(
+                            start=interval["start"].isoformat(),
+                            end=interval["end"].isoformat(),
+                        )
+                        for interval in data.get("busy", [])
+                    ],
+                    errors=[
+                        err.get("reason", str(err)) if isinstance(err, dict) else str(err)
+                        for err in (data.get("errors") or [])
+                    ],
+                )
+            )
+        return FreeBusyResult(
+            time_min=start.isoformat(),
+            time_max=end.isoformat(),
+            calendars=calendars,
+        )
+
+    result = await srv._run(work)
+    unreadable = [c.calendar_id for c in result.calendars if c.errors]
+    if unreadable:
+        await srv._warn(ctx, f"Free/busy could not be read for: {', '.join(unreadable)}.")
+    return result
+
+
+# ---------------------------------------------------------------------------
+# schedule_mutual
+#
+# Two ways to place the meeting, with the same contract:
+#
+# * When the preferences reduce to one plain daily clock window over every day
+#   the search touches -- no lunch, no buffer, no days off, no timezone skew --
+#   Google's own first-slot search in ``calendar_actions`` is exactly right, and
+#   is used unchanged.
+# * Otherwise the constraints cannot be expressed as a single 'HH:MM'-'HH:MM'
+#   pair, so the slot is found here: working windows from the preferences, minus
+#   everyone's busy time, minus the buffer.
+# ---------------------------------------------------------------------------
+
+
+def _clocks_agree(zone, *moments: datetime) -> bool:
+    """True when ``zone``'s wall clock matches each moment's own at that instant."""
+    return all(moment.astimezone(zone).utcoffset() == moment.utcoffset() for moment in moments)
+
+
+def _uniform_clock_window(
+    prefs: "preferences_module.Preferences",
+    time_min: datetime,
+    time_max: datetime,
+    zone,
+) -> Optional[Tuple[dt_time, dt_time]]:
+    """The single daily window the preferences reduce to, or ``None``.
+
+    ``None`` means the constraints need the richer search: a lunch break, a
+    buffer, a day off inside the window, or hours that differ by weekday.
+    """
+    if prefs.lunch or prefs.buffer_minutes:
+        return None
+    span: Optional[Tuple[str, str]] = None
+    for day in iter_days(time_min, time_max, zone):
+        day_spans = prefs.spans_for(day.weekday())
+        if len(day_spans) != 1:
+            return None
+        if span is None:
+            span = day_spans[0]
+        elif day_spans[0] != span:
+            return None
+    if span is None:
+        return None
+    start_clock = parse_clock(span[0], "working hours start")
+    end_clock = parse_clock(span[1], "working hours end")
+    if start_clock is None or end_clock is None:  # pragma: no cover - validated on write
+        return None
+    return start_clock, end_clock
+
+
+def _narrow(day_windows: List[Interval], start_clock, end_clock, zone) -> List[Interval]:
+    """Clips each working window to an explicit ``HH:MM`` bound on its own day."""
+    if start_clock is None and end_clock is None:
+        return day_windows
+    narrowed: List[Interval] = []
+    for window in day_windows:
+        day = window[0].astimezone(zone).date()
+        low = combine(day, start_clock, zone) if start_clock else window[0]
+        high = combine(day, end_clock, zone) if end_clock else window[1]
+        narrowed.extend(clip_intervals([window], (low, high)))
+    return narrowed
+
+
+@srv.server.tool(
+    name="schedule_mutual",
+    title="Find a mutual slot and schedule",
+    annotations=srv.WRITE,
+)
+async def schedule_mutual(
+    attendee_calendar_ids: List[str],
+    time_min: str,
+    time_max: str,
+    duration_minutes: int,
+    summary: str,
+    description: Optional[str] = None,
+    location: Optional[str] = None,
+    organizer_calendar_id: str = "primary",
+    working_hours_start: Optional[str] = None,
+    working_hours_end: Optional[str] = None,
+    send_notifications: bool = True,
+    respect_preferences: bool = True,
+    account: Optional[str] = None,
+    ctx: Optional[srv.Context] = None,
+) -> EventResult:
+    """Find the first slot where everyone is free, then book the meeting there.
+
+    Reads each attendee's free/busy inside the window, picks the earliest gap
+    that fits `duration_minutes`, and creates the event with all of them invited.
+    Fails with an error if no common slot exists -- widen the window or shorten
+    the meeting and try again.
+
+    By default the search obeys the user's own settings from `get_preferences`:
+    their working hours per weekday (so nothing lands on a day off), their lunch
+    break, and the buffer they want around meetings. `working_hours_start` and
+    `working_hours_end` narrow that further; they never widen it.
+
+    Args:
+        attendee_calendar_ids: Attendee email addresses whose availability matters.
+        time_min: Earliest the meeting may start, ISO 8601 with a UTC offset.
+        time_max: Latest the meeting may end, ISO 8601 with a UTC offset.
+        duration_minutes: Length of the meeting in minutes.
+        summary: Title for the meeting.
+        description: Optional agenda or notes.
+        location: Optional location or meeting link.
+        organizer_calendar_id: Calendar the meeting is created on.
+        working_hours_start: Optional daily earliest start, 'HH:MM' local to the
+            calendar, e.g. '09:00'.
+        working_hours_end: Optional daily latest end, 'HH:MM', e.g. '17:00'.
+        send_notifications: Whether Google emails the attendees. Default true.
+        respect_preferences: Obey the user's saved working hours, lunch and
+            buffer. Set false to search the whole window instead.
+        account: Account name from 'calendar-mcp accounts'; omit for the default.
+    """
+    provider = srv._provider(ctx)
+    problems: List[str] = []
+
+    def work() -> EventResult:
+        if duration_minutes <= 0:
+            raise srv.CalendarToolError("duration_minutes must be greater than zero.")
+        if not attendee_calendar_ids:
+            raise srv.CalendarToolError(
+                "attendee_calendar_ids must contain at least one address."
+            )
+        explicit_start = srv._parse_clock(working_hours_start, "working_hours_start")
+        explicit_end = srv._parse_clock(working_hours_end, "working_hours_end")
+
+        creds = provider.get(account)
+        start = srv._require(
+            srv.parse_datetime(time_min, "time_min", creds, organizer_calendar_id), "time_min"
+        )
+        end = srv._require(
+            srv.parse_datetime(time_max, "time_max", creds, organizer_calendar_id), "time_max"
+        )
+        if end - start < timedelta(minutes=duration_minutes):
+            raise srv.CalendarToolError(
+                "The search window is shorter than duration_minutes; widen time_min/time_max."
+            )
+
+        prefs = preferences_module.load() if respect_preferences else None
+        uniform = None
+        zone = None
+        if prefs is not None:
+            zone = prefs.tzinfo(None) or srv._default_tzinfo(creds, organizer_calendar_id)
+            if _clocks_agree(zone, start, end):
+                uniform = _uniform_clock_window(prefs, start, end, zone)
+
+        if prefs is None or uniform is not None:
+            clock_start, clock_end = (uniform or (None, None))
+            # The tighter of the two bounds wins: explicit args narrow, never widen.
+            if explicit_start and (clock_start is None or explicit_start > clock_start):
+                clock_start = explicit_start
+            if explicit_end and (clock_end is None or explicit_end < clock_end):
+                clock_end = explicit_end
+            return _book_first_slot(
+                creds, start, end, clock_start, clock_end, prefs is not None
+            )
+
+        return _book_within_preferences(creds, prefs, zone, start, end, explicit_start, explicit_end)
+
+    def _book_first_slot(creds, start, end, clock_start, clock_end, honoured) -> EventResult:
+        """Books via Google's own first-slot search in ``calendar_actions``."""
+        placeholder = EventDateTime(dateTime=start)
+        details = EventCreateRequest(
+            summary=summary,
+            start=placeholder,
+            end=placeholder,
+            description=description,
+            location=location,
+        )
+        created = srv.calendar_actions.find_mutual_availability_and_schedule(
+            credentials=creds,
+            attendee_calendar_ids=list(attendee_calendar_ids),
+            time_min=start,
+            time_max=end,
+            duration_minutes=duration_minutes,
+            event_details=details,
+            organizer_calendar_id=organizer_calendar_id,
+            working_hours_start=clock_start,
+            working_hours_end=clock_end,
+            send_notifications=send_notifications,
+        )
+        if created is None:
+            raise _no_slot(start, end, honoured)
+        return _result(created)
+
+    def _book_within_preferences(
+        creds, prefs, zone, start, end, explicit_start, explicit_end
+    ) -> EventResult:
+        """Finds the slot here, because the constraints are richer than one clock range."""
+        windows = _narrow(
+            preferences_module.working_windows(prefs, start, end, zone),
+            explicit_start,
+            explicit_end,
+            zone,
+        )
+        if not windows:
+            raise srv.CalendarToolError(
+                "That window contains no working time at all (see get_preferences). "
+                "Widen time_min/time_max, or pass respect_preferences=false."
+            )
+
+        # The organiser has to be free too, not just the attendees.
+        lookup = list(dict.fromkeys([organizer_calendar_id, *attendee_calendar_ids]))
+        raw = srv.calendar_actions.find_availability(
+            credentials=creds, time_min=start, time_max=end, calendar_ids=lookup
+        )
+        if raw is None:
+            raise srv._no_result("Querying free/busy")
+        busy: List[Interval] = []
+        for cal_id, data in raw.items():
+            for error in data.get("errors") or []:
+                reason = error.get("reason", str(error)) if isinstance(error, dict) else str(error)
+                problems.append(f"{cal_id}: {reason}")
+            for interval in data.get("busy", []):
+                busy.append((interval["start"], interval["end"]))
+
+        blocks = scheduling_logic.candidate_blocks(
+            windows,
+            busy,
+            min_block_minutes=duration_minutes,
+            buffer_minutes=prefs.buffer_minutes,
+        )
+        if not blocks:
+            raise _no_slot(start, end, True)
+        slot_start = blocks[0][0]
+        slot_end = slot_start + timedelta(minutes=duration_minutes)
+
+        invitees = [address for address in attendee_calendar_ids if "@" in address]
+        details = EventCreateRequest(
+            summary=summary,
+            start=EventDateTime(dateTime=slot_start),
+            end=EventDateTime(dateTime=slot_end),
+            description=description,
+            location=location,
+            attendees=invitees or None,
+        )
+        created = srv.calendar_actions.create_event(
+            credentials=creds,
+            event_data=details,
+            calendar_id=organizer_calendar_id,
+            send_notifications=send_notifications,
+        )
+        if created is None:
+            raise srv._no_result("Creating the meeting")
+        return _result(created)
+
+    def _no_slot(start, end, honoured) -> srv.CalendarToolError:
+        hint = (
+            " Widen the window, shorten the meeting, or relax the working-hours bounds."
+            if not honoured
+            else " Widen the window, shorten the meeting, or pass respect_preferences=false "
+            "to ignore the saved working hours, lunch and buffer."
+        )
+        return srv.CalendarToolError(
+            f"No {duration_minutes}-minute slot is free for everyone between "
+            f"{start.isoformat()} and {end.isoformat()}.{hint}"
+        )
+
+    def _result(created) -> EventResult:
+        info = EventInfo.from_event(created)
+        return EventResult(
+            calendar_id=organizer_calendar_id,
+            event=info,
+            message=(
+                f"Booked '{summary}' at {info.start} with "
+                f"{len(attendee_calendar_ids)} attendee(s)."
+            ),
+        )
+
+    result = await srv._run(work)
+    if problems:
+        await srv._warn(
+            ctx,
+            "Free/busy could not be read for: " + "; ".join(problems)
+            + ". Those calendars were treated as free.",
+        )
+    return result

--- a/example.env
+++ b/example.env
@@ -7,9 +7,33 @@
 GOOGLE_CLIENT_ID='YOUR_GOOGLE_CLIENT_ID_HERE'
 GOOGLE_CLIENT_SECRET='YOUR_GOOGLE_CLIENT_SECRET_HERE'
 
-# Where the user's OAuth token is cached after `calendar-mcp auth`.
-# Default: .gcp-saved-tokens.json in the current working directory.
-TOKEN_FILE_PATH='.gcp-saved-tokens.json'
+# --- Accounts and configuration -------------------------------------------
+# calendar-mcp can be signed in to several Google accounts at once. Each has a
+# short name and its own token file under <config dir>/accounts/<name>.json:
+#
+#   calendar-mcp auth                  # signs in the "default" account
+#   calendar-mcp auth --account work   # signs in a second account
+#   calendar-mcp accounts              # lists them
+#
+# Every MCP tool then takes an optional `account` argument; omit it for the
+# default. The same directory holds preferences.json (working hours, lunch,
+# meeting buffer, focus-block length), written by the `set_preferences` tool.
+
+# Where account tokens and preferences.json live.
+# Default: the platform user config directory for "calendar-mcp" --
+#   Windows  %APPDATA%\calendar-mcp
+#   macOS    ~/Library/Application Support/calendar-mcp
+#   Linux    ~/.config/calendar-mcp
+# CALENDAR_MCP_CONFIG_DIR='/path/to/calendar-mcp-config'
+
+# Account used when a tool's `account` argument is omitted. Default: "default".
+# CALENDAR_MCP_DEFAULT_ACCOUNT='work'
+
+# Legacy single-account token location, still fully supported: when this is set
+# (or ./.gcp-saved-tokens.json exists) it *is* the "default" account's token, so
+# an install from before multi-account support keeps working with no re-auth.
+# Leave it unset to let the config directory above hold every account.
+# TOKEN_FILE_PATH='.gcp-saved-tokens.json'
 
 # Local port the OAuth callback server listens on during `calendar-mcp auth`.
 # A "Desktop app" OAuth client accepts http://localhost on any port, so the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "calendar-mcp-server"
-version = "1.0.1"
+version = "1.1.0"
 description = "A single-process MCP server that gives LLM clients read and write access to Google Calendar."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -31,6 +31,7 @@ dependencies = [
     "python-dotenv",
     "requests",
     "tzdata",
+    "platformdirs",
 ]
 
 [project.optional-dependencies]
@@ -51,4 +52,4 @@ Homepage = "https://github.com/deciduus/calendar-mcp"
 Repository = "https://github.com/deciduus/calendar-mcp"
 
 [tool.setuptools]
-packages = ["calendar_mcp"]
+packages = ["calendar_mcp", "calendar_mcp.tools"]

--- a/scripts/smoke_stdio.py
+++ b/scripts/smoke_stdio.py
@@ -21,7 +21,7 @@ import anyio
 from mcp import ClientSession
 from mcp.client.stdio import StdioServerParameters, stdio_client
 
-EXPECTED_TOOL_COUNT = 15
+EXPECTED_TOOL_COUNT = 23
 
 
 async def smoke(command: str) -> int:
@@ -32,6 +32,8 @@ async def smoke(command: str) -> int:
             "GOOGLE_CLIENT_SECRET": "smoke-test-client-secret",
             # Point at a path that cannot exist, so the run proves no token is needed.
             "TOKEN_FILE_PATH": os.path.join(tempfile.gettempdir(), "calendar-mcp-no-such-token.json"),
+            # Same for the multi-account config directory.
+            "CALENDAR_MCP_CONFIG_DIR": os.path.join(tempfile.gettempdir(), "calendar-mcp-no-such-config"),
             "CALENDAR_MCP_LOG_LEVEL": "WARNING",
         }
     )

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.deciduus/calendar-mcp",
   "description": "Google Calendar for LLM agents: find, create, update, move, delete events; free/busy; scheduling.",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "repository": {
     "url": "https://github.com/deciduus/calendar-mcp",
     "source": "github"
@@ -12,7 +12,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "calendar-mcp-server",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -31,8 +31,15 @@
         },
         {
           "name": "TOKEN_FILE_PATH",
-          "description": "Path to the saved OAuth token file written by 'calendar-mcp auth'.",
-          "default": ".gcp-saved-tokens.json"
+          "description": "Optional legacy single-token path. Leave unset to store accounts in the config directory."
+        },
+        {
+          "name": "CALENDAR_MCP_CONFIG_DIR",
+          "description": "Directory holding per-account tokens and preferences.json. Defaults to the OS user config directory."
+        },
+        {
+          "name": "CALENDAR_MCP_DEFAULT_ACCOUNT",
+          "description": "Account name used when a tool's 'account' argument is omitted."
         }
       ]
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,10 @@ os.environ.setdefault("GOOGLE_CLIENT_SECRET", "dummy-client-secret")
 # Point the token file somewhere that cannot exist, so nothing picks up a real
 # token from the developer's working copy.
 os.environ["TOKEN_FILE_PATH"] = str(REPO_ROOT / "tests" / ".no-such-token.json")
+# Point the multi-account config directory somewhere that cannot exist either,
+# so account discovery and preferences never see the developer's real config.
+os.environ["CALENDAR_MCP_CONFIG_DIR"] = str(REPO_ROOT / "tests" / ".no-such-config")
+os.environ.pop("CALENDAR_MCP_DEFAULT_ACCOUNT", None)
 # Never let a test open a browser.
 os.environ["CALENDAR_MCP_ALLOW_BROWSER_AUTH"] = "0"
 

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,530 @@
+"""Tests for the time audit: pure maths in calendar_mcp.audit, plus the tool.
+
+Every event here is hand-made. Nothing in this file touches the network, and
+the only Google-shaped thing is ``calendar_actions.find_events``, which the tool
+test replaces with a stub.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from calendar_mcp import audit as audit_logic
+from calendar_mcp import server as server_module
+from calendar_mcp.audit import AuditEvent, build_audit, event_from_google, size_bucket
+from calendar_mcp.preferences import Preferences
+
+TZ = ZoneInfo("UTC")
+
+# A Monday, so the default Mon-Fri 09:00-17:00 working hours apply.
+MONDAY = datetime(2026, 3, 2, 0, 0, tzinfo=TZ)
+WEEK = (MONDAY, MONDAY + timedelta(days=7))
+MONDAY_ONLY = (MONDAY, MONDAY + timedelta(days=1))
+
+
+def at(day_offset: int, hour: int, minute: int = 0) -> datetime:
+    """A timestamp ``day_offset`` days after Monday, at ``hour:minute`` UTC."""
+    return MONDAY + timedelta(days=day_offset, hours=hour, minutes=minute)
+
+
+def meeting(
+    day_offset: int,
+    start_hour: float,
+    end_hour: float,
+    attendees=(),
+    **kwargs,
+) -> AuditEvent:
+    """A one-off meeting on ``day_offset`` between the two wall-clock hours."""
+    start = MONDAY + timedelta(days=day_offset, hours=start_hour)
+    end = MONDAY + timedelta(days=day_offset, hours=end_hour)
+    kwargs.setdefault("summary", "Meeting")
+    kwargs.setdefault("self_email", "me@corp.com")
+    return AuditEvent(start=start, end=end, attendees=list(attendees), **kwargs)
+
+
+def prefs(**overrides) -> Preferences:
+    """Default preferences (Mon-Fri 09:00-17:00 UTC) with overrides applied."""
+    base = {"timezone": "UTC"}
+    base.update(overrides)
+    return Preferences(**base)
+
+
+# ---------------------------------------------------------------------------
+# Small pure helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "count,expected",
+    [(0, "solo"), (1, "solo"), (2, "1:1"), (3, "small"), (4, "small"), (5, "large"), (30, "large")],
+)
+def test_size_bucket_boundaries(count, expected):
+    assert size_bucket(count) == expected
+
+
+def test_split_email_domain():
+    assert audit_logic.split_email_domain("Alice@Corp.com") == "corp.com"
+    assert audit_logic.split_email_domain("not-an-address") == ""
+
+
+def test_others_drops_self_and_duplicates():
+    event = meeting(0, 9, 10, ["me@corp.com", "Alice@corp.com", "alice@corp.com", ""])
+    assert event.others() == ["alice@corp.com"]
+
+
+# ---------------------------------------------------------------------------
+# Normalisation from the Google shape
+# ---------------------------------------------------------------------------
+
+
+def test_event_from_google_reads_a_timed_event():
+    raw = {
+        "summary": "Sync",
+        "start": {"dateTime": "2026-03-02T09:00:00Z"},
+        "end": {"dateTime": "2026-03-02T10:00:00Z"},
+        "organizer": {"email": "boss@corp.com"},
+        "recurringEventId": "series-1",
+        "transparency": "transparent",
+        "attendees": [
+            {"email": "me@corp.com", "self": True, "responseStatus": "declined"},
+            {"email": "boss@corp.com", "responseStatus": "accepted"},
+            {"email": "room-a@corp.com", "resource": True},
+        ],
+    }
+    event = event_from_google(raw, TZ, calendar_id="primary")
+    assert event is not None
+    assert event.summary == "Sync"
+    assert event.start == at(0, 9) and event.end == at(0, 10)
+    assert event.attendees == ["me@corp.com", "boss@corp.com"]  # resource dropped
+    assert event.self_email == "me@corp.com"
+    assert event.is_declined is True
+    assert event.is_free is True
+    assert event.is_recurring is True
+    assert event.all_day is False
+    assert event.calendar_id == "primary"
+
+
+def test_event_from_google_reads_an_all_day_event():
+    raw = {"start": {"date": "2026-03-02"}, "end": {"date": "2026-03-03"}}
+    event = event_from_google(raw, TZ)
+    assert event is not None and event.all_day is True
+    assert event.start == MONDAY and event.end == MONDAY + timedelta(days=1)
+
+
+def test_event_from_google_rejects_unusable_events():
+    assert event_from_google({"start": {"dateTime": "nonsense"}, "end": {}}, TZ) is None
+    assert event_from_google({}, TZ) is None
+    # end before start
+    assert event_from_google(
+        {"start": {"dateTime": "2026-03-02T10:00:00Z"}, "end": {"dateTime": "2026-03-02T09:00:00Z"}},
+        TZ,
+    ) is None
+
+
+def test_event_from_google_accepts_a_pydantic_style_object():
+    raw = SimpleNamespace(
+        summary="Object event",
+        start=SimpleNamespace(dateTime=at(0, 11)),
+        end=SimpleNamespace(dateTime=at(0, 12)),
+        attendees=[SimpleNamespace(email="alice@corp.com", self=None, responseStatus="accepted")],
+        organizer=SimpleNamespace(email="alice@corp.com", self=None),
+        recurring_event_id=None,
+    )
+    event = event_from_google(raw, TZ)
+    assert event is not None and event.attendees == ["alice@corp.com"]
+
+
+# ---------------------------------------------------------------------------
+# Exclusions
+# ---------------------------------------------------------------------------
+
+
+def test_declined_free_and_all_day_events_are_excluded():
+    events = [
+        meeting(0, 9, 10),
+        meeting(0, 10, 11, self_response_status="declined"),
+        meeting(0, 11, 12, transparency="transparent"),
+        AuditEvent(start=MONDAY, end=MONDAY + timedelta(days=1), all_day=True),
+        meeting(20, 9, 10),  # far outside the window
+    ]
+    result = build_audit(events, WEEK, prefs(), TZ)
+    assert result.total_meeting_count == 1
+    assert result.total_meeting_hours == 1.0
+    assert result.excluded.declined == 1
+    assert result.excluded.marked_free == 1
+    assert result.excluded.all_day == 1
+    assert result.excluded.outside_window == 1
+
+
+def test_include_flags_bring_the_excluded_events_back():
+    events = [
+        meeting(0, 9, 10, self_response_status="declined"),
+        AuditEvent(start=at(0, 0), end=at(1, 0), all_day=True),
+    ]
+    result = build_audit(events, WEEK, prefs(), TZ, include_all_day=True, include_declined=True)
+    assert result.total_meeting_count == 2
+    assert result.total_meeting_hours == 25.0
+    assert result.excluded.declined == 0
+
+
+# ---------------------------------------------------------------------------
+# Totals, periods and shares
+# ---------------------------------------------------------------------------
+
+
+def test_totals_and_share_of_working_hours():
+    # Two hours of meetings on Monday, out of a 40-hour Mon-Fri week.
+    events = [meeting(0, 9, 10), meeting(0, 14, 15)]
+    result = build_audit(events, WEEK, prefs(), TZ)
+    assert result.total_meeting_hours == 2.0
+    assert result.working_hours_available == 40.0
+    assert result.share_of_working_hours == 0.05
+
+
+def test_meeting_time_outside_working_hours_does_not_inflate_the_share():
+    # 07:00-09:00 is before the working day: counted as meeting time, but only
+    # the part inside working hours counts towards the share.
+    result = build_audit([meeting(0, 7, 9)], WEEK, prefs(), TZ)
+    assert result.total_meeting_hours == 2.0
+    assert result.meeting_hours_in_working_hours == 0.0
+    assert result.share_of_working_hours == 0.0
+
+
+def test_overlapping_meetings_double_count_hours_but_not_the_share():
+    events = [meeting(0, 9, 11), meeting(0, 9, 11)]
+    result = build_audit(events, MONDAY_ONLY, prefs(), TZ)
+    assert result.total_meeting_hours == 4.0
+    assert result.meeting_hours_in_working_hours == 2.0
+    assert result.share_of_working_hours == 0.25  # 2h of an 8h day
+
+
+def test_events_are_clipped_to_the_window():
+    long_event = AuditEvent(start=at(0, 8), end=at(2, 8), self_email="me@corp.com")
+    result = build_audit([long_event], MONDAY_ONLY, prefs(), TZ)
+    assert result.total_meeting_hours == 16.0  # 08:00 Monday to midnight
+
+
+def test_group_by_day_gives_one_period_per_day():
+    result = build_audit([meeting(0, 9, 10)], WEEK, prefs(), TZ, group_by="day")
+    assert result.group_by == "day"
+    assert len(result.periods) == 7
+    assert result.periods[0].period == "2026-03-02"
+    assert result.periods[0].meeting_hours == 1.0
+    assert result.periods[0].working_hours == 8.0
+    assert result.periods[1].meeting_hours == 0.0
+
+
+def test_group_by_week_gives_one_period_per_iso_week():
+    events = [meeting(0, 9, 10), meeting(7, 9, 11)]
+    window = (MONDAY, MONDAY + timedelta(days=14))
+    result = build_audit(events, window, prefs(), TZ, group_by="week")
+    assert [period.period for period in result.periods] == ["2026-W10", "2026-W11"]
+    assert result.periods[0].meeting_hours == 1.0
+    assert result.periods[1].meeting_hours == 2.0
+    assert result.busiest_period is not None
+    assert result.busiest_period.period == "2026-W11"
+
+
+def test_longest_meeting_day_is_a_day_even_when_grouped_by_week():
+    events = [meeting(0, 9, 10), meeting(1, 9, 13)]
+    result = build_audit(events, WEEK, prefs(), TZ, group_by="week")
+    assert result.longest_meeting_day is not None
+    assert result.longest_meeting_day.period == "2026-03-03"  # Tuesday
+    assert result.longest_meeting_day.meeting_hours == 4.0
+
+
+def test_empty_calendar_reports_no_longest_day():
+    result = build_audit([], WEEK, prefs(), TZ)
+    assert result.longest_meeting_day is None
+    assert result.busiest_period is None
+    assert result.total_meeting_hours == 0.0
+    assert result.insights == [
+        "No meetings in this window -- all of your working time was unbooked."
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Breakdowns
+# ---------------------------------------------------------------------------
+
+
+def test_breakdown_by_size():
+    events = [
+        meeting(0, 9, 10, ["me@corp.com", "alice@corp.com"]),                      # 1:1
+        meeting(0, 10, 12, ["me@corp.com", "alice@corp.com", "bob@corp.com"]),     # small
+        meeting(1, 9, 12, ["me@corp.com"] + [f"p{i}@corp.com" for i in range(9)]),  # large
+        meeting(2, 9, 10),                                                          # solo
+    ]
+    result = build_audit(events, WEEK, prefs(), TZ)
+    hours = {bucket.label: bucket.hours for bucket in result.by_size}
+    assert hours == {"1:1": 1.0, "small": 2.0, "large": 3.0, "solo": 1.0}
+    shares = {bucket.label: bucket.share_of_meeting_hours for bucket in result.by_size}
+    assert shares["large"] == pytest.approx(3.0 / 7.0, abs=1e-4)
+
+
+def test_breakdown_by_domain_counts_a_mixed_meeting_in_both_domains():
+    events = [meeting(0, 9, 11, ["me@corp.com", "alice@corp.com", "dan@vendor.io"])]
+    result = build_audit(events, WEEK, prefs(), TZ)
+    hours = {bucket.label: bucket.hours for bucket in result.by_domain}
+    assert hours == {"corp.com": 2.0, "vendor.io": 2.0}
+
+
+def test_top_people_are_ranked_by_hours_and_capped():
+    events = [
+        meeting(0, 9, 12, ["me@corp.com", "alice@corp.com"]),
+        meeting(1, 9, 10, ["me@corp.com", "alice@corp.com", "bob@corp.com"]),
+    ]
+    result = build_audit(events, WEEK, prefs(), TZ)
+    assert [(p.email, p.hours, p.meeting_count) for p in result.top_people] == [
+        ("alice@corp.com", 4.0, 2),
+        ("bob@corp.com", 1.0, 1),
+    ]
+
+    many = [
+        meeting(0, 9 + i * 0.25, 9.25 + i * 0.25, ["me@corp.com", f"p{i:02d}@corp.com"])
+        for i in range(15)
+    ]
+    capped = build_audit(many, WEEK, prefs(), TZ)
+    assert len(capped.top_people) == 10
+
+
+def test_breakdown_by_recurrence():
+    events = [
+        meeting(0, 9, 11, recurring_event_id="series-1"),
+        meeting(1, 9, 10),
+    ]
+    result = build_audit(events, WEEK, prefs(), TZ)
+    hours = {bucket.label: bucket.hours for bucket in result.by_recurrence}
+    assert hours == {"recurring": 2.0, "one-off": 1.0}
+
+
+# ---------------------------------------------------------------------------
+# Back-to-back stretches
+# ---------------------------------------------------------------------------
+
+
+def test_three_touching_meetings_are_one_back_to_back_stretch():
+    events = [meeting(0, 9, 10), meeting(0, 10, 11), meeting(0, 11, 12)]
+    result = build_audit(events, WEEK, prefs(buffer_minutes=15), TZ)
+    assert result.back_to_back_count == 1
+    assert result.back_to_back_hours == 3.0
+    stretch = result.back_to_back_stretches[0]
+    assert stretch.meeting_count == 3
+    assert stretch.date == "2026-03-02"
+    assert stretch.start == at(0, 9).isoformat()
+    assert stretch.end == at(0, 12).isoformat()
+
+
+def test_two_touching_meetings_are_not_a_stretch():
+    events = [meeting(0, 9, 10), meeting(0, 10, 11)]
+    result = build_audit(events, WEEK, prefs(buffer_minutes=15), TZ)
+    assert result.back_to_back_count == 0
+    assert result.back_to_back_stretches == []
+
+
+def test_a_gap_at_least_as_wide_as_the_buffer_breaks_the_stretch():
+    # 30-minute gaps with a 15-minute buffer: comfortable, so no stretch.
+    events = [meeting(0, 9, 10), meeting(0, 10.5, 11.5), meeting(0, 12, 13)]
+    assert build_audit(events, WEEK, prefs(buffer_minutes=15), TZ).back_to_back_count == 0
+    # The same day judged against a one-hour buffer is one long stretch.
+    assert build_audit(events, WEEK, prefs(buffer_minutes=60), TZ).back_to_back_count == 1
+
+
+def test_back_to_back_gap_can_be_overridden():
+    events = [meeting(0, 9, 10), meeting(0, 10.5, 11.5), meeting(0, 12, 13)]
+    result = build_audit(events, WEEK, prefs(), TZ, back_to_back_gap_minutes=45)
+    assert result.back_to_back_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Focus time
+# ---------------------------------------------------------------------------
+
+
+def test_focus_time_on_an_empty_working_day():
+    result = build_audit([], MONDAY_ONLY, prefs(), TZ)
+    assert result.focus_block_count == 1
+    assert result.focus_hours_available == 8.0
+    assert result.largest_focus_blocks[0].start == at(0, 9).isoformat()
+
+
+def test_lunch_splits_the_focus_blocks():
+    result = build_audit([], MONDAY_ONLY, prefs(lunch=("12:00", "13:00")), TZ)
+    assert [block.hours for block in result.largest_focus_blocks] == [4.0, 3.0]
+    assert result.focus_hours_available == 7.0
+
+
+def test_short_gaps_do_not_count_as_focus_time():
+    # 09:00-12:00 and 12:30-17:00 booked leaves a 30-minute gap, below the
+    # 60-minute default minimum.
+    events = [meeting(0, 9, 12), meeting(0, 12.5, 17)]
+    result = build_audit(events, MONDAY_ONLY, prefs(), TZ)
+    assert result.focus_block_count == 0
+    assert result.focus_hours_available == 0.0
+
+
+def test_the_buffer_shrinks_the_focus_blocks():
+    events = [meeting(0, 9, 10)]
+    without = build_audit(events, MONDAY_ONLY, prefs(), TZ)
+    withbuf = build_audit(events, MONDAY_ONLY, prefs(buffer_minutes=30), TZ)
+    assert without.focus_hours_available == 7.0
+    assert withbuf.focus_hours_available == 6.5
+
+
+def test_min_focus_block_is_respected():
+    events = [meeting(0, 11, 12)]
+    relaxed = build_audit(events, MONDAY_ONLY, prefs(min_focus_block_minutes=60), TZ)
+    strict = build_audit(events, MONDAY_ONLY, prefs(min_focus_block_minutes=180), TZ)
+    assert [block.hours for block in relaxed.largest_focus_blocks] == [5.0, 2.0]
+    assert [block.hours for block in strict.largest_focus_blocks] == [5.0]
+
+
+# ---------------------------------------------------------------------------
+# Insights
+# ---------------------------------------------------------------------------
+
+
+def test_insights_are_three_to_five_readable_lines():
+    events = [
+        meeting(0, 9, 10, ["me@corp.com", "alice@corp.com"]),
+        meeting(1, 9, 13, ["me@corp.com", "alice@corp.com"]),
+        meeting(1, 13, 14, ["me@corp.com", "alice@corp.com"]),
+        meeting(1, 14, 15, ["me@corp.com", "bob@corp.com"]),
+    ]
+    result = build_audit(events, WEEK, prefs(buffer_minutes=15), TZ)
+    assert 3 <= len(result.insights) <= 5
+    joined = " ".join(result.insights)
+    assert "% of your working hours went to meetings" in joined
+    assert "Tuesdays are your heaviest day" in joined
+    assert "Most time with alice@corp.com" in joined
+    assert "back-to-back stretch" in joined
+
+
+def test_insights_mention_recurring_share_when_nothing_is_back_to_back():
+    events = [meeting(0, 9, 11, ["me@corp.com", "alice@corp.com"], recurring_event_id="s1")]
+    result = build_audit(events, WEEK, prefs(), TZ)
+    assert any("recurring" in line for line in result.insights)
+
+
+# ---------------------------------------------------------------------------
+# Timezone handling
+# ---------------------------------------------------------------------------
+
+
+def test_days_are_grouped_in_the_reporting_timezone():
+    berlin = ZoneInfo("Europe/Berlin")
+    # 23:30 UTC on Monday is 00:30 on Tuesday in Berlin.
+    event = AuditEvent(start=at(0, 23, 30), end=at(1, 0, 30), self_email="me@corp.com")
+    result = build_audit([event], WEEK, prefs(timezone="Europe/Berlin"), berlin, group_by="day")
+    by_period = {period.period: period.meeting_hours for period in result.periods}
+    assert by_period["2026-03-03"] == 1.0
+    assert by_period["2026-03-02"] == 0.0
+    assert result.timezone == "Europe/Berlin"
+
+
+# ---------------------------------------------------------------------------
+# The tool
+# ---------------------------------------------------------------------------
+
+
+def _google_event(start: datetime, end: datetime, **extra):
+    payload = {
+        "summary": "Sync",
+        "start": {"dateTime": start.isoformat()},
+        "end": {"dateTime": end.isoformat()},
+    }
+    payload.update(extra)
+    return payload
+
+
+@pytest.mark.anyio
+async def test_time_audit_tool_reports_over_the_fetched_events(monkeypatch):
+    from calendar_mcp.tools.audit import time_audit
+
+    calls = []
+
+    def fake_find_events(credentials, calendar_id="primary", **kwargs):
+        calls.append(calendar_id)
+        return SimpleNamespace(
+            items=[
+                _google_event(
+                    at(0, 9),
+                    at(0, 10),
+                    attendees=[
+                        {"email": "me@corp.com", "self": True, "responseStatus": "accepted"},
+                        {"email": "alice@corp.com"},
+                    ],
+                ),
+                _google_event(
+                    at(0, 10),
+                    at(0, 11),
+                    attendees=[{"email": "me@corp.com", "self": True, "responseStatus": "declined"}],
+                ),
+            ]
+        )
+
+    monkeypatch.setattr(
+        server_module.calendar_actions, "find_events", fake_find_events, raising=False
+    )
+    monkeypatch.setattr(
+        server_module.CredentialProvider, "get", lambda self, account=None: object()
+    )
+    monkeypatch.setattr(server_module, "_default_tzinfo", lambda creds, calendar_id: TZ)
+
+    result = await time_audit(
+        time_min=MONDAY.isoformat(),
+        time_max=(MONDAY + timedelta(days=7)).isoformat(),
+        calendar_ids=["primary", "team@corp.com"],
+        group_by="day",
+    )
+
+    assert calls == ["primary", "team@corp.com"]
+    # The same two events come back from both calendars; one of each is declined.
+    assert result.total_meeting_count == 2
+    assert result.total_meeting_hours == 2.0
+    assert result.excluded.declined == 2
+    assert result.group_by == "day"
+    assert result.calendar_ids == ["primary", "team@corp.com"]
+    assert result.top_people[0].email == "alice@corp.com"
+
+
+@pytest.mark.anyio
+async def test_time_audit_tool_rejects_an_inverted_window(monkeypatch):
+    from calendar_mcp.tools.audit import time_audit
+
+    monkeypatch.setattr(
+        server_module.CredentialProvider, "get", lambda self, account=None: object()
+    )
+    monkeypatch.setattr(server_module, "_default_tzinfo", lambda creds, calendar_id: TZ)
+
+    with pytest.raises(server_module.CalendarToolError):
+        await time_audit(
+            time_min=(MONDAY + timedelta(days=1)).isoformat(),
+            time_max=MONDAY.isoformat(),
+        )
+
+
+@pytest.mark.anyio
+async def test_time_audit_tool_fails_when_no_calendar_can_be_read(monkeypatch):
+    from calendar_mcp.tools.audit import time_audit
+
+    monkeypatch.setattr(
+        server_module.calendar_actions,
+        "find_events",
+        lambda credentials, calendar_id="primary", **kwargs: None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        server_module.CredentialProvider, "get", lambda self, account=None: object()
+    )
+    monkeypatch.setattr(server_module, "_default_tzinfo", lambda creds, calendar_id: TZ)
+
+    with pytest.raises(server_module.CalendarToolError):
+        await time_audit(
+            time_min=MONDAY.isoformat(),
+            time_max=(MONDAY + timedelta(days=1)).isoformat(),
+        )

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -1,0 +1,620 @@
+"""Tests for the scheduling logic and the tools built on it.
+
+Two layers, deliberately separate:
+
+* :mod:`calendar_mcp.scheduling` is pure, so its tests are hand-made intervals
+  and plain assertions -- no server, no mocks, no clock.
+* The tools (``find_focus_time``, ``block_focus_time``, ``detect_conflicts``,
+  ``suggest_reschedule``) are driven through the real ``MCPServer``, with
+  ``calendar_actions`` patched, exactly as ``tests/test_server.py`` does it.
+"""
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from mcp.server.mcpserver.exceptions import ToolError
+
+from calendar_mcp import scheduling
+from calendar_mcp import server as server_module
+from calendar_mcp.models import (
+    CalendarListEntry,
+    CalendarListResponse,
+    EventsResponse,
+    GoogleCalendarEvent,
+)
+
+UTC = timezone.utc
+
+
+def dt(day: int, hour: int, minute: int = 0) -> datetime:
+    """A UTC moment in January 2026. The 1st is a Thursday, the 3rd a Saturday."""
+    return datetime(2026, 1, day, hour, minute, tzinfo=UTC)
+
+
+def span(day: int, start_hour: float, end_hour: float):
+    """A ``(start, end)`` interval on one January 2026 day, in decimal hours."""
+    def moment(value: float) -> datetime:
+        return dt(day, int(value), int(round((value - int(value)) * 60)))
+
+    return moment(start_hour), moment(end_hour)
+
+
+WORKDAY = span(1, 9, 17)
+
+
+# ==========================================================================
+# Pure logic: measuring
+# ==========================================================================
+
+
+def test_interval_minutes_ignores_inverted_intervals():
+    assert scheduling.interval_minutes(span(1, 9, 10.5)) == 90.0
+    assert scheduling.interval_minutes((dt(1, 12), dt(1, 9))) == 0.0
+
+
+def test_total_hours_merges_overlaps_rather_than_double_counting():
+    overlapping = [span(1, 9, 11), span(1, 10, 12)]
+    assert scheduling.total_hours(overlapping) == 3.0
+    assert scheduling.total_hours([span(1, 9, 10), span(1, 11, 12)]) == 2.0
+
+
+def test_overlap_minutes_treats_touching_intervals_as_separate():
+    assert scheduling.overlap_minutes(span(1, 9, 10), span(1, 10, 11)) == 0.0
+    assert scheduling.overlap_minutes(span(1, 9, 11), span(1, 10, 12)) == 60.0
+
+
+# ==========================================================================
+# Pure logic: focus blocks
+# ==========================================================================
+
+
+def test_candidate_blocks_cuts_busy_time_out_of_the_working_day():
+    blocks = scheduling.candidate_blocks([WORKDAY], [span(1, 11, 12)], min_block_minutes=60)
+
+    assert blocks == [span(1, 9, 11), span(1, 12, 17)]
+
+
+def test_candidate_blocks_leaves_the_buffer_on_both_sides_of_a_meeting():
+    blocks = scheduling.candidate_blocks(
+        [WORKDAY], [span(1, 11, 12)], min_block_minutes=60, buffer_minutes=15
+    )
+
+    assert blocks == [span(1, 9, 10.75), span(1, 12.25, 17)]
+
+
+def test_candidate_blocks_drops_stretches_shorter_than_the_minimum():
+    blocks = scheduling.candidate_blocks(
+        [WORKDAY], [span(1, 10, 16)], min_block_minutes=90
+    )
+
+    # 09:00-10:00 is only an hour, so only the... nothing survives: 16:00-17:00
+    # is an hour too.
+    assert blocks == []
+
+
+def test_candidate_blocks_keeps_each_working_window_separate():
+    morning, afternoon = span(1, 9, 12), span(1, 13, 17)  # lunch already removed
+
+    blocks = scheduling.candidate_blocks([morning, afternoon], [], min_block_minutes=60)
+
+    assert blocks == [morning, afternoon]
+
+
+def test_rank_blocks_puts_the_longest_first_then_the_earliest():
+    short_early, long_late, equal_later = span(1, 9, 11), span(1, 12, 17), span(2, 9, 11)
+
+    assert scheduling.rank_blocks([short_early, long_late, equal_later]) == [
+        long_late,
+        short_early,
+        equal_later,
+    ]
+
+
+def test_select_blocks_trims_the_last_block_to_what_is_still_needed():
+    blocks = [span(1, 9, 11), span(1, 12, 17)]
+
+    chosen = scheduling.select_blocks(blocks, hours_needed=6, min_block_minutes=60)
+
+    # The five-hour block first, then one hour of the two-hour one, in date order.
+    assert chosen == [span(1, 9, 10), span(1, 12, 17)]
+    assert scheduling.total_hours(chosen) == 6.0
+
+
+def test_select_blocks_never_trims_below_the_minimum_block():
+    chosen = scheduling.select_blocks([span(1, 9, 17)], hours_needed=0.25, min_block_minutes=60)
+
+    assert chosen == [span(1, 9, 10)]
+
+
+def test_select_blocks_takes_what_it_can_when_the_week_is_too_full():
+    chosen = scheduling.select_blocks([span(1, 9, 11)], hours_needed=8, min_block_minutes=60)
+
+    assert chosen == [span(1, 9, 11)]
+    assert scheduling.total_hours(chosen) == 2.0
+
+
+def test_select_blocks_selects_nothing_when_nothing_is_needed():
+    assert scheduling.select_blocks([span(1, 9, 17)], hours_needed=0) == []
+
+
+# ==========================================================================
+# Pure logic: conflicts
+# ==========================================================================
+
+
+def test_overlapping_pairs_reports_the_overlap_and_ignores_touching_events():
+    events = [span(1, 9, 10), span(1, 10, 11), span(1, 9.5, 10.5)]
+
+    pairs = scheduling.overlapping_pairs(events)
+
+    assert pairs == [(0, 2, 30.0), (2, 1, 30.0)]
+
+
+def test_overlapping_pairs_finds_a_meeting_nested_inside_another():
+    events = [span(1, 9, 12), span(1, 10, 11)]
+
+    assert scheduling.overlapping_pairs(events) == [(0, 1, 60.0)]
+
+
+def test_overlapping_pairs_is_empty_for_a_clean_day():
+    assert scheduling.overlapping_pairs([span(1, 9, 10), span(1, 11, 12)]) == []
+
+
+def test_tight_pairs_reports_gaps_smaller_than_the_buffer():
+    events = [span(1, 9, 10), span(1, 10.25, 11), span(1, 12, 13)]
+
+    assert scheduling.tight_pairs(events, buffer_minutes=30) == [(0, 1, 15.0)]
+
+
+def test_tight_pairs_ignores_overlaps_and_an_unset_buffer():
+    overlapping = [span(1, 9, 11), span(1, 10, 12)]
+
+    assert scheduling.tight_pairs(overlapping, buffer_minutes=30) == []
+    assert scheduling.tight_pairs([span(1, 9, 10), span(1, 10, 11)], buffer_minutes=0) == []
+
+
+def test_tight_pairs_counts_back_to_back_meetings_as_tight():
+    events = [span(1, 9, 10), span(1, 10, 11)]
+
+    assert scheduling.tight_pairs(events, buffer_minutes=15) == [(0, 1, 0.0)]
+
+
+# ==========================================================================
+# Pure logic: slots and ranking
+# ==========================================================================
+
+
+def test_align_up_moves_to_the_next_quarter_hour():
+    assert scheduling.align_up(dt(1, 9, 7), 15) == dt(1, 9, 15)
+    assert scheduling.align_up(dt(1, 9, 15), 15) == dt(1, 9, 15)
+    assert scheduling.align_up(dt(1, 9, 46), 15) == dt(1, 10, 0)
+
+
+def test_generate_slots_places_them_on_the_grid_inside_the_window():
+    slots = scheduling.generate_slots([span(1, 9, 10)], duration_minutes=30, step_minutes=15)
+
+    assert slots == [span(1, 9, 9.5), span(1, 9.25, 9.75), span(1, 9.5, 10)]
+
+
+def test_generate_slots_stops_at_the_limit_and_refuses_a_zero_duration():
+    slots = scheduling.generate_slots([WORKDAY], duration_minutes=60, step_minutes=15, limit=3)
+
+    assert len(slots) == 3
+    assert scheduling.generate_slots([WORKDAY], duration_minutes=0) == []
+
+
+def test_conflicting_keys_names_only_the_busy_attendees():
+    busy = {
+        "free@example.com": [span(1, 15, 16)],
+        "busy@example.com": [span(1, 9.5, 10)],
+    }
+
+    assert scheduling.conflicting_keys(span(1, 9, 10), busy) == ["busy@example.com"]
+
+
+def test_violates_buffer_only_for_a_gap_that_is_too_small():
+    assert scheduling.violates_buffer(span(1, 10, 11), [span(1, 9.75, 10)], 30) is True
+    assert scheduling.violates_buffer(span(1, 10, 11), [span(1, 9, 9.5)], 30) is False
+    # An overlap is a conflict, not a buffer problem.
+    assert scheduling.violates_buffer(span(1, 10, 11), [span(1, 10.5, 12)], 30) is False
+
+
+def test_rank_slots_prefers_no_conflicts_then_the_original_day_then_earliest():
+    clashing_early = span(1, 9, 10)
+    clean_late = span(1, 15, 16)
+    clean_next_day = span(2, 9, 10)
+
+    ranked = scheduling.rank_slots(
+        [clashing_early, clean_late, clean_next_day],
+        busy_by_key={"guest@example.com": [span(1, 9, 10)]},
+        original_start=dt(1, 14),
+        tzinfo=UTC,
+    )
+
+    assert [(slot.start, slot.score) for slot in ranked] == [
+        (clean_late[0], 110.0),   # free, and on the day the meeting is already on
+        (clean_next_day[0], 100.0),
+        (clashing_early[0], 85.0),  # busy attendee (-25) but same day (+10)
+    ]
+    assert ranked[-1].conflicts == ("guest@example.com",)
+    assert "busy: guest@example.com" in ranked[-1].reasons
+
+
+def test_rank_slots_drops_slots_the_organiser_cannot_make():
+    ranked = scheduling.rank_slots(
+        [span(1, 9, 10), span(1, 11, 12)],
+        unavailable=[span(1, 9.5, 10.5)],
+    )
+
+    assert [slot.start for slot in ranked] == [dt(1, 11)]
+
+
+def test_rank_slots_penalises_a_slot_that_eats_the_buffer():
+    ranked = scheduling.rank_slots(
+        [span(1, 11, 12)],
+        busy_by_key={"guest@example.com": [span(1, 10, 10.75)]},
+        buffer_minutes=30,
+    )
+
+    assert ranked[0].score == 92.0
+    assert "less than 30 min from another meeting" in ranked[0].reasons
+
+
+def test_rank_slots_honours_the_limit():
+    slots = scheduling.generate_slots([WORKDAY], duration_minutes=60)
+
+    assert len(scheduling.rank_slots(slots, limit=3)) == 3
+
+
+# ==========================================================================
+# Tool level
+# ==========================================================================
+
+
+@pytest.fixture
+def actions():
+    """Patches calendar_actions and pins the credential provider, as test_server does."""
+    provider = MagicMock(name="CredentialProvider")
+    provider.get.return_value = MagicMock(name="credentials")
+    fake = MagicMock(name="calendar_actions")
+    fake.get_calendar_timezone.return_value = "UTC"
+    fake.find_calendars.return_value = CalendarListResponse(
+        items=[CalendarListEntry(etag='"1"', id="primary", summary="Me", primary=True)]
+    )
+    with patch.object(server_module, "credential_provider", provider), \
+            patch.object(server_module, "calendar_actions", fake):
+        fake.provider = provider
+        yield fake
+
+
+def busy_response(**calendars):
+    """Builds what calendar_actions.find_availability returns."""
+    return {
+        calendar_id: {
+            "busy": [{"start": start, "end": end} for start, end in intervals],
+            "errors": [],
+        }
+        for calendar_id, intervals in calendars.items()
+    }
+
+
+def event_payload(event_id, start, end, summary="Meeting", **extra):
+    payload = {
+        "id": event_id,
+        "summary": summary,
+        "status": "confirmed",
+        "start": {"dateTime": start.isoformat()},
+        "end": {"dateTime": end.isoformat()},
+    }
+    payload.update(extra)
+    return GoogleCalendarEvent(**payload)
+
+
+async def structured(name, arguments):
+    result = await server_module.server.call_tool(name, arguments)
+    assert result.is_error is False, result.content
+    assert result.structured_content is not None
+    return result.structured_content
+
+
+async def test_find_focus_time_reports_the_gaps_in_the_working_day(actions):
+    actions.find_availability.return_value = busy_response(primary=[span(1, 11, 12)])
+
+    data = await structured("find_focus_time", {
+        "time_min": "2026-01-01T00:00:00Z",
+        "time_max": "2026-01-02T00:00:00Z",
+        "hours_needed": 4,
+    })
+
+    # Default preferences: Thursday 09:00-17:00, one hour booked at 11:00.
+    assert data["total_free_hours"] == 7.0
+    assert data["satisfiable"] is True
+    assert data["count"] == 2
+    # Longest block first, and only the calendars the account has selected.
+    assert [block["start"] for block in data["blocks"]] == [
+        "2026-01-01T12:00:00+00:00",
+        "2026-01-01T09:00:00+00:00",
+    ]
+    assert data["blocks"][0]["duration_minutes"] == 300.0
+    assert data["blocks"][0]["weekday"] == "Thursday"
+    assert data["calendar_ids"] == ["primary"]
+
+
+async def test_find_focus_time_says_when_the_week_cannot_supply_the_hours(actions):
+    actions.find_availability.return_value = busy_response(primary=[span(1, 10, 17)])
+
+    data = await structured("find_focus_time", {
+        "time_min": "2026-01-01T00:00:00Z",
+        "time_max": "2026-01-02T00:00:00Z",
+        "hours_needed": 4,
+        "calendar_ids": ["primary", "work@example.com"],
+    })
+
+    assert data["satisfiable"] is False
+    assert data["total_free_hours"] == 1.0
+    assert "Only 1 of the 4 focus hours" in data["message"]
+    assert actions.find_availability.call_args.kwargs["calendar_ids"] == [
+        "primary",
+        "work@example.com",
+    ]
+
+
+async def test_block_focus_time_dry_run_previews_without_writing(actions):
+    actions.find_availability.return_value = busy_response(primary=[span(1, 11, 12)])
+
+    data = await structured("block_focus_time", {
+        "time_min": "2026-01-01T00:00:00Z",
+        "time_max": "2026-01-02T00:00:00Z",
+        "hours_needed": 6,
+        "dry_run": True,
+    })
+
+    actions.create_event.assert_not_called()
+    assert data["dry_run"] is True
+    assert data["hours_booked"] == 6.0
+    assert data["satisfied"] is True
+    # Longest block whole, then the last block trimmed to the remaining hour.
+    assert [(event["start"], event["end"]) for event in data["events"]] == [
+        ("2026-01-01T09:00:00+00:00", "2026-01-01T10:00:00+00:00"),
+        ("2026-01-01T12:00:00+00:00", "2026-01-01T17:00:00+00:00"),
+    ]
+    assert all(event["created"] is False for event in data["events"])
+
+
+async def test_block_focus_time_books_the_blocks_it_picked(actions):
+    actions.find_availability.return_value = busy_response(primary=[])
+    actions.create_event.return_value = event_payload(
+        "focus-1", dt(1, 9), dt(1, 11), summary="Deep work"
+    )
+
+    data = await structured("block_focus_time", {
+        "time_min": "2026-01-01T00:00:00Z",
+        "time_max": "2026-01-02T00:00:00Z",
+        "hours_needed": 2,
+        "title": "Deep work",
+    })
+
+    assert data["count"] == 1
+    assert data["events"][0]["created"] is True
+    assert data["events"][0]["event_id"] == "focus-1"
+    kwargs = actions.create_event.call_args.kwargs
+    assert kwargs["calendar_id"] == "primary"  # preferences.focus_calendar_id
+    assert kwargs["send_notifications"] is False
+    created = kwargs["event_data"]
+    assert created.summary == "Deep work"
+    assert created.reminders.useDefault is False
+
+
+async def test_block_focus_time_refuses_when_nothing_is_free(actions):
+    actions.find_availability.return_value = busy_response(primary=[span(1, 9, 17)])
+
+    with pytest.raises(ToolError, match="No free block of at least 60 minutes"):
+        await server_module.server.call_tool("block_focus_time", {
+            "time_min": "2026-01-01T00:00:00Z",
+            "time_max": "2026-01-02T00:00:00Z",
+            "hours_needed": 2,
+        })
+
+    actions.create_event.assert_not_called()
+
+
+async def test_detect_conflicts_finds_the_double_booking(actions):
+    actions.find_events.return_value = EventsResponse(items=[
+        event_payload("a", dt(1, 9), dt(1, 10), summary="Standup"),
+        event_payload("b", dt(1, 9, 30), dt(1, 10, 30), summary="Client call"),
+        event_payload("c", dt(1, 14), dt(1, 15), summary="Alone"),
+    ])
+
+    data = await structured("detect_conflicts", {
+        "time_min": "2026-01-01T00:00:00Z",
+        "time_max": "2026-01-02T00:00:00Z",
+    })
+
+    assert data["event_count"] == 3
+    assert data["conflict_count"] == 1
+    conflict = data["conflicts"][0]
+    assert (conflict["first"]["summary"], conflict["second"]["summary"]) == (
+        "Standup",
+        "Client call",
+    )
+    assert conflict["overlap_minutes"] == 30.0
+    assert conflict["same_calendar"] is True
+    assert data["accounts"] == ["default"]
+    assert data["calendar_ids"] == ["default:primary"]
+
+
+async def test_detect_conflicts_ignores_declined_and_all_day_events(actions):
+    actions.find_events.return_value = EventsResponse(items=[
+        event_payload("a", dt(1, 9), dt(1, 10)),
+        event_payload(
+            "b", dt(1, 9), dt(1, 10), summary="Declined",
+            attendees=[{"email": "me@example.com", "self": True, "responseStatus": "declined"}],
+        ),
+        GoogleCalendarEvent(
+            id="c", summary="Holiday", status="confirmed",
+            start={"date": "2026-01-01"}, end={"date": "2026-01-02"},
+        ),
+    ])
+
+    data = await structured("detect_conflicts", {
+        "time_min": "2026-01-01T00:00:00Z",
+        "time_max": "2026-01-02T00:00:00Z",
+    })
+
+    assert data["event_count"] == 1
+    assert data["conflict_count"] == 0
+    assert "No conflicts" in data["message"]
+
+
+async def test_detect_conflicts_can_be_asked_to_include_all_day_events(actions):
+    actions.find_events.return_value = EventsResponse(items=[
+        event_payload("a", dt(1, 9), dt(1, 10), summary="Standup"),
+        GoogleCalendarEvent(
+            id="c", summary="Holiday", status="confirmed",
+            start={"date": "2026-01-01"}, end={"date": "2026-01-02"},
+        ),
+    ])
+
+    data = await structured("detect_conflicts", {
+        "time_min": "2026-01-01T00:00:00Z",
+        "time_max": "2026-01-02T00:00:00Z",
+        "include_all_day": True,
+    })
+
+    assert data["event_count"] == 2
+    assert data["conflict_count"] == 1
+    conflict = data["conflicts"][0]
+    assert conflict["first"]["summary"] == "Holiday"
+    assert conflict["first"]["all_day"] is True
+    assert conflict["overlap_minutes"] == 60.0
+
+
+async def test_suggest_reschedule_ranks_times_the_attendee_can_make(actions):
+    actions.get_event.return_value = event_payload(
+        "evt-1", dt(1, 14), dt(1, 15), summary="1:1",
+        attendees=[
+            {"email": "me@example.com", "self": True, "responseStatus": "accepted"},
+            {"email": "guest@example.com", "responseStatus": "accepted"},
+        ],
+    )
+    actions.find_availability.return_value = busy_response(
+        primary=[span(1, 14, 15)],                      # the meeting itself
+        **{"guest@example.com": [span(1, 9, 11)]},
+    )
+
+    data = await structured("suggest_reschedule", {
+        "event_id": "evt-1",
+        "search_from": "2026-01-01T09:00:00Z",
+        "search_days": 1,
+        "max_suggestions": 3,
+    })
+
+    assert data["applied"] is False
+    assert data["duration_minutes"] == 60.0
+    assert data["attendees"] == ["guest@example.com"]
+    assert data["count"] == 3
+    best = data["suggestions"][0]
+    assert best["start"] == "2026-01-01T11:00:00+00:00"
+    assert best["attendee_conflicts"] == []
+    assert "same day as the original" in best["reasons"]
+    actions.move_event.assert_not_called()
+
+
+async def test_suggest_reschedule_can_apply_the_top_suggestion(actions):
+    actions.get_event.return_value = event_payload("evt-1", dt(1, 14), dt(1, 15))
+    actions.find_availability.return_value = busy_response(primary=[span(1, 14, 15)])
+    actions.move_event.return_value = event_payload("evt-1", dt(1, 9), dt(1, 10))
+
+    data = await structured("suggest_reschedule", {
+        "event_id": "evt-1",
+        "search_from": "2026-01-01T09:00:00Z",
+        "search_days": 1,
+        "apply": True,
+    })
+
+    assert data["applied"] is True
+    assert data["applied_event"]["id"] == "evt-1"
+    kwargs = actions.move_event.call_args.kwargs
+    assert kwargs["new_start"] == dt(1, 9)
+    assert kwargs["new_end"] == dt(1, 10)
+    assert "Moved" in data["message"]
+
+
+async def test_suggest_reschedule_rejects_an_all_day_event(actions):
+    actions.get_event.return_value = GoogleCalendarEvent(
+        id="evt-1", summary="Holiday", status="confirmed",
+        start={"date": "2026-01-01"}, end={"date": "2026-01-02"},
+    )
+
+    with pytest.raises(ToolError, match="needs a timed event"):
+        await server_module.server.call_tool("suggest_reschedule", {"event_id": "evt-1"})
+
+
+async def test_schedule_mutual_falls_back_to_its_own_search_when_lunch_is_set(actions):
+    """A lunch break cannot be expressed as one clock range, so the tool places the slot."""
+    from calendar_mcp import preferences as preferences_module
+
+    prefs = preferences_module.Preferences(lunch=("12:00", "13:00"), buffer_minutes=15)
+    actions.find_availability.return_value = busy_response(
+        primary=[span(1, 9, 11.5)],
+        **{"guest@example.com": []},
+    )
+    actions.create_event.return_value = event_payload("new-1", dt(1, 13), dt(1, 14))
+
+    with patch.object(preferences_module, "load", return_value=prefs):
+        data = await structured("schedule_mutual", {
+            "attendee_calendar_ids": ["guest@example.com"],
+            "time_min": "2026-01-01T09:00:00Z",
+            "time_max": "2026-01-01T17:00:00Z",
+            "duration_minutes": 60,
+            "summary": "Sync",
+        })
+
+    actions.find_mutual_availability_and_schedule.assert_not_called()
+    created = actions.create_event.call_args.kwargs["event_data"]
+    # 11:30 is free but the 15-minute buffer and the 12:00 lunch leave no full
+    # hour before lunch, so the first workable slot is straight after it.
+    assert created.start.dateTime == dt(1, 13)
+    assert created.end.dateTime == dt(1, 14)
+    assert created.attendees == ["guest@example.com"]
+    assert "Booked 'Sync'" in data["message"]
+
+
+async def test_schedule_mutual_keeps_using_google_search_for_plain_preferences(actions):
+    actions.find_mutual_availability_and_schedule.return_value = event_payload(
+        "new-2", dt(1, 9), dt(1, 9, 30), summary="Chat"
+    )
+
+    await structured("schedule_mutual", {
+        "attendee_calendar_ids": ["guest@example.com"],
+        "time_min": "2026-01-01T09:00:00Z",
+        "time_max": "2026-01-01T17:00:00Z",
+        "duration_minutes": 30,
+        "summary": "Chat",
+    })
+
+    # Default preferences are a plain 09:00-17:00 weekday, so they are passed
+    # straight to the existing search rather than duplicating it here.
+    kwargs = actions.find_mutual_availability_and_schedule.call_args.kwargs
+    assert kwargs["working_hours_start"].hour == 9
+    assert kwargs["working_hours_end"].hour == 17
+    actions.create_event.assert_not_called()
+
+
+async def test_schedule_mutual_can_ignore_preferences_entirely(actions):
+    actions.find_mutual_availability_and_schedule.return_value = event_payload(
+        "new-3", dt(3, 9), dt(3, 9, 30), summary="Weekend"
+    )
+
+    await structured("schedule_mutual", {
+        "attendee_calendar_ids": ["guest@example.com"],
+        "time_min": "2026-01-03T00:00:00Z",   # a Saturday: not a working day
+        "time_max": "2026-01-03T23:00:00Z",
+        "duration_minutes": 30,
+        "summary": "Weekend",
+        "respect_preferences": False,
+    })
+
+    kwargs = actions.find_mutual_availability_and_schedule.call_args.kwargs
+    assert kwargs["working_hours_start"] is None
+    assert kwargs["working_hours_end"] is None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -42,6 +42,14 @@ EXPECTED_TOOLS = {
     "respond_to_event",
     "schedule_mutual",
     "delete_event",
+    "list_accounts",
+    "get_preferences",
+    "set_preferences",
+    "time_audit",
+    "find_focus_time",
+    "block_focus_time",
+    "detect_conflicts",
+    "suggest_reschedule",
 }
 
 READ_ONLY_TOOLS = {
@@ -51,6 +59,11 @@ READ_ONLY_TOOLS = {
     "query_free_busy",
     "analyze_busyness",
     "project_recurring_events",
+    "list_accounts",
+    "get_preferences",
+    "time_audit",
+    "find_focus_time",
+    "detect_conflicts",
 }
 
 EVENT_PAYLOAD = {
@@ -116,10 +129,10 @@ async def structured(name, arguments=None):
 # --- tool registry ------------------------------------------------------------
 
 
-async def test_list_tools_exposes_exactly_the_expected_fifteen():
+async def test_list_tools_exposes_exactly_the_expected_set():
     tools = await server_module.server.list_tools()
     assert {t.name for t in tools} == EXPECTED_TOOLS
-    assert len(tools) == 15
+    assert len(tools) == len(EXPECTED_TOOLS) == 23
 
 
 async def test_every_tool_has_a_description_and_output_schema():
@@ -149,7 +162,7 @@ async def test_tool_annotations_classify_reads_writes_and_deletes():
 
 async def test_server_identity_and_instructions():
     assert server_module.server.name == "calendar-mcp"
-    assert server_module.SERVER_VERSION == "1.0.1"
+    assert server_module.SERVER_VERSION == "1.1.0"
     assert "calendar_id" in server_module.INSTRUCTIONS
 
 
@@ -289,6 +302,32 @@ async def test_find_events_caches_the_calendar_timezone_lookup(actions):
     await structured("find_events", {"time_min": "2026-01-02T09:00:00"})
 
     assert actions.get_calendar_timezone.call_count == 1
+
+
+async def test_the_calendar_timezone_cache_does_not_leak_across_accounts(actions):
+    """'primary' is a different calendar, in a different zone, per account."""
+    zones = {"work": "America/New_York", "personal": "Europe/Berlin"}
+
+    def creds_for(account=None):
+        creds = MagicMock(name=f"credentials-{account}")
+        creds._calendar_mcp_account = account
+        return creds
+
+    actions.provider.get.side_effect = creds_for
+    actions.get_calendar_timezone.side_effect = (
+        lambda creds, calendar_id: zones[creds._calendar_mcp_account]
+    )
+    actions.find_events.return_value = EventsResponse(items=[])
+
+    await structured("find_events", {"time_min": "2026-01-01T09:00:00", "account": "work"})
+    work_min = actions.find_events.call_args.kwargs["time_min"]
+
+    await structured("find_events", {"time_min": "2026-01-01T09:00:00", "account": "personal"})
+    personal_min = actions.find_events.call_args.kwargs["time_min"]
+
+    # 09:00 New York is 14:00 UTC; 09:00 Berlin is 08:00 UTC.
+    assert work_min.astimezone(UTC) == datetime(2026, 1, 1, 14, tzinfo=UTC)
+    assert personal_min.astimezone(UTC) == datetime(2026, 1, 1, 8, tzinfo=UTC)
 
 
 async def test_find_events_rejects_an_unparseable_timestamp(actions):

--- a/tests/test_stdio_handshake.py
+++ b/tests/test_stdio_handshake.py
@@ -35,6 +35,14 @@ EXPECTED_TOOLS = {
     "respond_to_event",
     "schedule_mutual",
     "delete_event",
+    "list_accounts",
+    "get_preferences",
+    "set_preferences",
+    "time_audit",
+    "find_focus_time",
+    "block_focus_time",
+    "detect_conflicts",
+    "suggest_reschedule",
 }
 
 HANDSHAKE_TIMEOUT_SECONDS = 60.0
@@ -81,11 +89,11 @@ async def test_stdio_subprocess_handshake_lists_all_tools():
         pytest.skip(f"Could not spawn the stdio server subprocess: {exc}")
 
     assert init.server_info.name == "calendar-mcp"
-    assert init.server_info.version == "1.0.1"
+    assert init.server_info.version == "1.1.0"
     assert init.instructions
 
     names = {tool.name for tool in listing.tools}
     assert names == EXPECTED_TOOLS
-    assert len(listing.tools) == 15
+    assert len(listing.tools) == len(EXPECTED_TOOLS) == 23
     # Every tool advertises structured output over the wire, not just in-process.
     assert all(tool.output_schema for tool in listing.tools)


### PR DESCRIPTION
## Summary
The "scheduling brain" release. 23 tools (was 15). All existing tool names and parameters unchanged; every Google-touching tool gains an optional `account`.

- **Multi-account.** `calendar-mcp auth --account work`, `calendar-mcp accounts`. Tokens live in a per-user config dir (`CALENDAR_MCP_CONFIG_DIR`); `TOKEN_FILE_PATH` and the legacy `.gcp-saved-tokens.json` still work as the `default` account.
- **Preferences.** `get_preferences` / `set_preferences`: timezone, working hours per weekday, lunch, buffer between meetings, minimum focus block, focus calendar. Stored in `preferences.json`.
- **New tools:** `find_focus_time`, `block_focus_time` (with `dry_run`), `detect_conflicts` (across accounts, flags buffer violations as "tight"), `suggest_reschedule` (ranked slots with reasons, `apply=False` by default), `time_audit` (meeting load per day/week, share of working hours, by size / person / domain, back-to-back stretches, focus time available, plain-English insights).
- `schedule_mutual` respects working hours, lunch and buffers (`respect_preferences=True`).
- Tools moved into `calendar_mcp/tools/*` modules; new pure-logic modules `scheduling.py`, `audit.py`, `timeutil.py`, `accounts.py`, `preferences.py`.
- Fixed a cross-account timezone cache leak found during review. `GoogleCalendarEvent` now carries `transparency`.
- README: Accounts, Preferences, Scheduling brain, Time audit, Safety sections. CHANGELOG 1.1.0.

## Test plan
- [x] Fresh venv `pip install -e ".[dev]" && pytest`: 218 passed
- [x] Real stdio handshake: 23 tools, 23/23 structured output
- [x] `uv build --wheel` includes `calendar_mcp/tools/`